### PR TITLE
yast2-python3-bindings incorrectly packages some files in '/'

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 29 15:49:44 UTC 2018 - dmulder@suse.com
+
+- Don't package files in '/' (bsc#1095054).
+
+-------------------------------------------------------------------
 Fri Mar  9 16:35:09 UTC 2018 - dmulder@suse.com
 
 - Adapt the bindings to allow modules that will run in both python2

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %endif
 
 Name:           yast2-python-bindings
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -22,11 +22,6 @@
 %define with_python3 0
 %endif
 
-%define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")
-%define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
-%define python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")
-%define python3_sitearch %(%{__python3} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
-
 Name:           yast2-python-bindings
 Version:        4.0.3
 Release:        0
@@ -50,6 +45,7 @@ BuildRequires:  python-devel
 BuildRequires:  python3
 BuildRequires:  python3-devel
 %endif
+BuildRequires:  python-rpm-macros
 BuildRequires:  swig
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-ycp-ui-bindings


### PR DESCRIPTION
python3_sitelib and python3_sitearch were being
generated because these macros had been removed
from python-rpm-macros. They've been put back now
so we can use them again.