### PR TITLE
Forward port old bindings code which handled python import from ruby/perl, etc

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Oct 29 20:06:34 UTC 2018 - dmulder@suse.com
+
+- Forward port python import capability.
+
+-------------------------------------------------------------------
 Tue Oct 16 16:16:58 CEST 2018 - schubi@suse.de
 
 - Added license file to spec.

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %endif
 
 Name:           yast2-python-bindings
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,31 +1,29 @@
 BUILT_SOURCES = ycp.py
-ycp.py yast-core_wrap.cxx: yast-core.i ytypes.i ycp.i $(libpy2UI) YCPMap.h y2log.i yast.h ytypes.h y2log.h PythonLogger.h Y2PythonClientComponent.h YPythonCode.h Y2CCPythonClient.h
+ycp.py yast-core_wrap.cxx: yast-core.i ytypes.i ycp.i $(libpy2UI) YCPMap.h y2log.i
 	$(SWIG) $(AX_SWIG_PYTHON_OPT) -c++ -I/usr/include/YaST2 -o $@ $<
 
 # Remove non-standard syntax unrecognized by swig from YCPMap.h
 YCPMap.h:
 	sed 's/__attribute__ ((deprecated)) //g' /usr/include/YaST2/ycp/YCPMap.h > YCPMap.h
 
-python_PYTHON = ycp.py yast.py ycpbuiltins.py
+python_PYTHON = ycp.py yast.py ycpbuiltins.py YCPDeclarations.py
 
-pyexec_LTLIBRARIES = _ycp.la
+noinst_HEADERS = PythonLogger.h y2log.h yast.h YPythonCode.h ytypes.h Y2CCPythonClient.h Y2PythonClientComponent.h YCPDeclarations.h YPython.h Y2CCPython.h Y2PythonComponent.h YCPMap.h YPythonNamespace.h
 
-_ycp_la_SOURCES = yast-core_wrap.cxx yast.cpp yast-core.i ytypes.i ycp.i YPythonCode.cc PythonLogger.cc y2log.i
-noinst_HEADERS = yast.h ytypes.h y2log.h PythonLogger.h Y2PythonClientComponent.h YPythonCode.h Y2CCPythonClient.h
-
-_ycp_la_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(py2langdir)
-
-_ycp_la_LIBADD = -L$(py2langdir) -lpy2UI
-
-_ycp_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
+install-exec-hook:
+	(cd ${pyexecdir}; $(LN_S) ${py2langdir}/libpy2lang_python.so _ycp.so || echo)
+uninstall-hook:
+	(cd ${pyexecdir}; rm -f _ycp.so || echo)
 
 py2lang_LTLIBRARIES = libpy2lang_python.la
 
-libpy2lang_python_la_SOURCES = Y2PythonClientComponent.cc Y2CCPythonClient.cc
+libpy2lang_python_la_SOURCES = Y2PythonComponent.cc Y2CCPython.cc YPython.cc YPythonNamespace.cc YCPDeclarations.cc yast.cpp yast-core_wrap.cxx Y2PythonClientComponent.cc Y2CCPythonClient.cc YPythonCode.cc PythonLogger.cc
 
-libpy2lang_python_la_LDFLAGS = ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+libpy2lang_python_la_LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
 
-libpy2lang_python_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate
+libpy2lang_python_la_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+
+libpy2lang_python_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
 
 AM_CXXFLAGS = -DY2LOG=\"Python\"
 

--- a/src/Y2CCPython.cc
+++ b/src/Y2CCPython.cc
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2CCPython.cc
+
+
+/-*/
+
+#include <Python.h>
+#include "Y2CCPython.h"
+#include <ycp/pathsearch.h>
+#define y2log_component "Y2Python"
+#include <ycp/y2log.h>
+
+// This is very important: We create one global variable of
+// Y2CCPython. Its constructor will register it automatically to
+// the Y2ComponentBroker, so that will be able to find it.
+// This all happens before main() is called!
+
+Y2CCPython g_y2ccpython;
+
+Y2Component *Y2CCPython::provideNamespace (const char *name)
+{
+    y2debug ("Y2CCPython::provideNamespace %s", name);
+    if (strcmp (name, "Python") == 0)
+    {
+	// low level functions
+
+	// leave implementation to later
+	return 0;
+    }
+    else
+    {
+	// is there a python module?
+	// must be the same in Y2CCPython and Y2PythonComponent
+	string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
+	if (!module.empty ())
+	{
+	    if (!cpython)
+	    {
+		cpython = new Y2PythonComponent ();
+	    }
+	    return cpython;
+	}
+
+	// let someone else try creating the namespace
+	return 0;
+    }
+}

--- a/src/Y2CCPython.h
+++ b/src/Y2CCPython.h
@@ -1,0 +1,73 @@
+/*-----------------------------------------------------------*- c++ -*-\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2CCPython.h
+
+/-*/
+
+#include <Python.h>
+#ifndef _Y2CCPython_h
+#define _Y2CCPython_h
+
+#include "Y2PythonComponent.h"
+
+/**
+ * @short Y2ComponentCreator that creates Python-from-YCP bindings.
+ *
+ * A Y2ComponentCreator is an object that can create components.
+ * It receives a component name and - if it knows how to create
+ * such a component - returns a newly created component of this
+ * type. Y2CCPython can create components with the name "Python".
+ */
+class Y2CCPython : public Y2ComponentCreator
+{
+private:
+    Y2Component *cpython;
+
+public:
+    /**
+     * Creates a Python component creator
+     */
+    Y2CCPython() : Y2ComponentCreator( Y2ComponentBroker::BUILTIN ),
+	cpython (0) {};
+
+    ~Y2CCPython () {
+	if (cpython)
+	    delete cpython;
+    }
+
+    /**
+     * Returns true, since the Python component is a YaST2 server.
+     */
+    bool isServerCreator() const { return true; };
+
+    /**
+     * Creates a new Python component.
+     */
+    Y2Component *create( const char * name ) const
+    {
+	// create as many as requested, they all share the static YPython anyway
+	if ( ! strcmp( name, "python") ) return new Y2PythonComponent();
+	else return 0;
+    }
+
+    /**
+     * always returns the same component, deletes it finally
+     */
+    Y2Component *provideNamespace (const char *name);
+
+};
+
+#endif	// ifndef _Y2CCPython_h
+
+
+// EOF

--- a/src/Y2PythonComponent.cc
+++ b/src/Y2PythonComponent.cc
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2PythonComponent.cc
+
+
+
+/-*/
+
+#define y2log_component "Y2Python"
+#include <Python.h>
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+#include "Y2PythonComponent.h"
+
+//XXX -> not rewrited
+#include "YPython.h"
+#include "YPythonNamespace.h"
+using std::string;
+
+
+Y2PythonComponent::Y2PythonComponent()
+{
+    // Actual creation of a Python interpreter is postponed until one of the
+    // YPython static methods is used. They handle that.
+
+    y2milestone( "Creating Y2PythonComponent" );
+}
+
+
+Y2PythonComponent::~Y2PythonComponent()
+{
+    YPython::destroy();
+}
+
+
+void Y2PythonComponent::result( const YCPValue & )
+{
+}
+
+
+Y2Namespace *Y2PythonComponent::import (const char* name)
+{
+    // TODO where to look for it
+    // must be the same in Y2CCPython and Y2PythonComponent
+
+    string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
+    if (module.empty ())
+    {
+	y2internal ("Couldn't find %s after Y2CCPython pointed to us", name);
+	return NULL;
+    }
+
+    //import module and add his dictionary to YPython::_pMainDicts
+    YPython::loadModule (module);
+
+    // introspect, create data structures for the interpreter
+    Y2Namespace *ns = new YPythonNamespace (name);
+
+    return ns;
+}

--- a/src/Y2PythonComponent.h
+++ b/src/Y2PythonComponent.h
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2PythonComponent.h
+
+
+
+/-*/
+
+
+#ifndef Y2PythonComponent_h
+#define Y2PythonComponent_h
+
+#include <Python.h>
+#include "Y2.h"
+
+
+/**
+ * @short YaST2 Component: Python bindings
+ */
+class Y2PythonComponent : public Y2Component
+{
+public:
+    /**
+     * Constructor.
+     */
+    Y2PythonComponent();
+
+    /**
+     * Destructor.
+     */
+    ~Y2PythonComponent();
+
+    /**
+     * The name of this component.
+     */
+    string name() const { return "python"; }
+
+    /**
+     * Is called by the generic frontend when the session is finished.
+     */
+    void result( const YCPValue & result );
+
+    /**
+     * Implements the Python:: functions.
+     **/
+// not yet, prototype the transparent bindings first
+//    YCPValue evaluate( const YCPValue & val );
+
+    /**
+     * Try to import a given namespace. This method is used
+     * for transparent handling of namespaces (YCP modules)
+     * through whole YaST.
+     * @param name_space the name of the required namespace
+     * @return on errors, NULL should be returned. The
+     * error reporting must be done by the component itself
+     * (typically using y2log). On success, the method
+     * should return a proper instance of the imported namespace
+     * ready to be used. The returned instance is still owned
+     * by the component, any other part of YaST will try to
+     * free it. Thus, it's possible to share the instance.
+     */
+    Y2Namespace *import (const char* name);
+};
+
+#endif	// Y2PythonComponent_h

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -1,0 +1,258 @@
+#include "YCPDeclarations.h"
+#include <iostream>
+
+#define y2log_component "YCPDeclarations"
+#include <ycp/y2log.h>
+
+using std::string;
+using std::vector;
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+
+/********** STATIC MEMBERS **********/
+YCPDeclarations YCPDeclarations::_instance;
+YCPDeclarations *YCPDeclarations::instance()
+{
+    return &_instance;
+}
+
+/********** STATIC MEMBERS END **********/
+
+
+
+
+/********** PRIVATE **********/
+bool YCPDeclarations::_isInCache(PyFunctionObject *func) const
+{
+    int len = _cache.size();
+    for (int i=0; i < len; i++){
+        if (_cache[i]->function == func)
+            return true;
+    }
+
+    return false;
+}
+
+void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
+{
+    PyObject *item;
+    PyObject *params;
+    PyObject *return_type;
+    PyObject *tmp;
+    cache_function_t *function;
+    Py_ssize_t tuple_size;
+
+    if (!_init())
+        return;
+
+    if (_isInCache(func)){
+        y2debug("function (%ld, %s) is already in cache.", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    item = _getItemFromFunctionMap((PyObject *)func);
+    if (item == NULL || !PyDict_Check(item)){
+        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    return_type = PyDict_GetItemString(item, "return_type");
+    if (return_type == NULL || !PyString_Check(return_type)){
+        y2debug("Invalid return type of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+    params = PyDict_GetItemString(item, "parameters");
+    if (params == NULL || !PyTuple_Check(params)){
+        y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    //allocate memory
+    function = new cache_function_t;
+
+    //function
+    function->function = func;
+
+    //return type:
+    function->return_type = _interpretType(PyString_AsString(return_type));
+
+    //parameters:
+    tuple_size = PyTuple_Size(params);
+    for (Py_ssize_t i=0; i < tuple_size; i++){
+        tmp = PyTuple_GetItem(params, i);
+        function->parameters.push_back(_interpretType(PyString_AsString(tmp)));
+    }
+
+    //add new function item
+    _cache.push_back(function);
+    y2debug("function (%ld, %s) cached", (long)func, PyString_AsString(func->func_name));
+}
+
+const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyFunctionObject *func) const
+{
+    cache_function_t *ret = NULL;
+    int len = _cache.size();
+
+    y2debug("Searching for function (%ld, %s)...", (long)func, PyString_AsString(func->func_name));
+    for (int i=0; i < len; i++){
+        if (_cache[i]->function == func){
+            y2debug("    ==> Function found on position %d", i);
+            ret = _cache[i];
+            break;
+        }
+    }
+
+    if (ret == NULL){
+        y2debug("    ==> Function not found");
+    }
+
+    return ret;
+}
+
+
+PyObject *YCPDeclarations::_getItemFromFunctionMap(PyObject *key)
+{
+    if (!_init())
+        return NULL;
+
+    if (_py_self == NULL)
+        return NULL;
+
+    PyObject *dict = PyModule_GetDict(_py_self);
+    PyObject *func_map = PyDict_GetItemString(dict, "_function_map");
+
+    if (!PyDict_Check(func_map)){
+        y2error("Map _function_map not found in python module YCPDeclarations");
+        return NULL;
+    }
+
+    return PyDict_GetItem(func_map, key);
+}
+
+
+constTypePtr YCPDeclarations::_interpretType(const char *c_type) const
+{
+    string type(c_type);
+
+    if (type == "void")
+        return Type::Void;
+    if (type == "boolean")
+        return Type::Boolean;
+    if (type == "float")
+        return Type::Float;
+    if (type == "integer")
+        return Type::Integer;
+    if (type == "path")
+        return Type::Path;
+    if (type == "string")
+        return Type::String;
+    if (type == "symbol")
+        return Type::Symbol;
+    if (type == "term")
+        return Type::Term;
+    if (type == "map")
+        return Type::Map;
+    if (type == "list")
+        return Type::List;
+
+    // default:
+    return Type::Any;
+}
+
+
+bool YCPDeclarations::_init()
+{
+    if (_py_self != NULL)
+        return true;
+
+    if (!Py_IsInitialized()){
+        y2error("Python interpret is not initialized!");
+        return false;
+    }
+
+    _py_self = PyImport_ImportModule("YCPDeclarations");
+    if (_py_self == NULL){
+        y2error("Failed to import YCPDeclarations module!");
+        return false;
+    }
+
+    y2milestone("YCPDeclarations successfuly initialized!");
+    return true;
+}
+/********** PRIVATE END **********/
+
+
+
+
+/********** PUBLIC **********/
+
+YCPDeclarations::YCPDeclarations() : _py_self(NULL)
+{
+    y2debug("Constructor called");
+}
+
+YCPDeclarations::~YCPDeclarations()
+{
+    int cache_len = _cache.size();
+    for (int i=0; i < cache_len; i++){
+        delete _cache[i];
+    }
+
+    if (_py_self != NULL)
+        Py_DECREF(_py_self);
+
+    y2debug("Destructor called");
+}
+
+
+int YCPDeclarations::numParams(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL)
+        return -1;
+
+    y2debug("Number of parameters of function (%ld, %s) is %d",
+            (long)func, PyString_AsString(func->func_name), (int)function->parameters.size());
+    return function->parameters.size();
+}
+
+bool YCPDeclarations::exists(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    return _isInCache(func);
+}
+
+vector<constTypePtr> YCPDeclarations::params(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL){
+        return vector<constTypePtr>();
+    }
+
+    return function->parameters;
+}
+
+constTypePtr YCPDeclarations::returnType(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL){
+        return _interpretType("any");
+    }
+
+    return function->return_type;
+}
+
+bool YCPDeclarations::init()
+{
+    return _init();
+}
+/********** PUBLIC END **********/

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -6,6 +6,9 @@
 
 using std::string;
 using std::vector;
+
+#include "compat.h"
+
 #define DBG(str) \
     std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
     std::cerr.flush()

--- a/src/YCPDeclarations.h
+++ b/src/YCPDeclarations.h
@@ -1,0 +1,137 @@
+#ifndef _YCPDECLARATIONS_H_
+#define _YCPDECLARATIONS_H_
+
+#include <Python.h>
+#include <ycp/Type.h>
+#include <vector>
+#include <string>
+#include <memory>
+
+/**
+ * This class stores information about declarations in python module which were
+ * done by YCPDeclarations module (YCPDeclaratios.py).
+ * This is class is singelton and static method instance() returns pointer to
+ * object.
+ *
+ * All methods which return any information about declared functions are
+ * called with argument pointer to PyFunctionObject (which identifies
+ * function unambiguously.
+ *
+ * Example of usage:
+ *
+ *      #include "YCPDeclarations.h"
+ *
+ *      PyObject *func = PyDict_GetItemString(dict, "function");
+ *      YCPDeclarations *decl = YCPDeclarations::instance();
+ *      int num_params = decl->numParams((PyFunctionObject *)func);
+ *      ...
+ *
+ */
+class YCPDeclarations {
+  private:
+    /**
+     * structure where can be stored cached function.
+     */
+    typedef struct{
+        PyFunctionObject *function;
+        constTypePtr return_type;
+        std::vector<constTypePtr> parameters;
+    } cache_function_t;
+
+
+    /**
+     * Pointer to Python module YCPDeclarations.
+     */
+    PyObject *_py_self;
+
+    /**
+     * List of cached functions.
+     */
+    std::vector<cache_function_t *> _cache;
+
+    /**
+     * Private construct.
+     * Call YCPDeclarations::instance() to get pointer to YCPDeclarations
+     * object.
+     */
+    YCPDeclarations();
+
+    /**
+     * Return item from function map which has key key.
+     * Return borrowed reference!
+     */
+    PyObject *_getItemFromFunctionMap(PyObject *key);
+
+    /**
+     * Interpret string as YCP type.
+     * This method must be synchronized with variable
+     * YCPDeclare._available_types from YCPDeclarations.py!!
+     */
+    constTypePtr _interpretType(const char *) const;
+
+    /**
+     * Return true, if func is in internal cache.
+     */
+    bool _isInCache(PyFunctionObject *func) const;
+
+    /**
+     * Cache function func if it is not already cached.
+     */
+    void _cacheFunction(PyFunctionObject *func);
+
+    /**
+     * Return pointer to struct which defines cached function.
+     * Memory pointed by returned pointer must _not_ be deleted! It points
+     * into internal list.
+     */
+    const cache_function_t *_getCachedFunction(PyFunctionObject *func) const;
+
+
+    /**
+     * Try to initialize _py_self. If _py_self is already initialized, nothing is done.
+     */
+    bool _init();
+
+  public:
+    ~YCPDeclarations();
+
+    /**
+     * Return number of parameters in declaration or -1 if function is not registered.
+     */
+    int numParams(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return true if function exists in YCPDeclarations module.
+     */
+    bool exists(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return list of YCP types corresponding with parameters fo function.
+     */
+    std::vector<constTypePtr> params(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return return YCP type of function.
+     */
+    constTypePtr returnType(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Initialize class.
+     */
+    bool init();
+
+  //static
+  private:
+    /**
+     * Here is stored pointer to YCPDeclare object.
+     */
+    static YCPDeclarations _instance;
+  public:
+    /**
+     * Return pointer to instance of YCPDeclare object.
+     */
+    static YCPDeclarations *instance();
+};
+
+#endif
+/* vim: set sw=4 ts=4 et ft=cpp cindent : */

--- a/src/YCPDeclarations.py
+++ b/src/YCPDeclarations.py
@@ -1,0 +1,105 @@
+"""
+ This module defines class YCPDeclare which can be used for defining
+ what return type and what types of arguments has function which will be
+ exported to YCP. For usage see YCPDeclare.__doc__.
+
+
+ Internal:
+ Important is variable _function_map which holds information about
+ functions. Contents of _function_map can be accessed from C:
+
+    PyObject *import = PyImport_ImportModule("YCPDeclarations");
+    PyObject *dict = PyModule_GetDict(import);
+    PyObject *func_map = PyDict_GetItemString(dict, "_function_map");
+    // now in func_map should be stored map describing functions declared by
+    // YCPDeclare
+
+ _function_map has form:
+    _function_map = {
+        pointer_to_function : {
+            "return_type" : "string",
+            "parameters" : [ list of strings representing types ]
+        }
+    }
+
+"""
+
+import inspect
+
+_function_map = {}
+def _addToFunctionMap(func_pointer, return_type, params_types):
+    global __function_map
+    _function_map[func_pointer] = {"return_type" : return_type,
+                                   "parameters" : params_types}
+
+class YCPDeclare:
+    """
+     Functor for definig return type and types of parameters
+     of function which will be exported into YCP. Best usage
+     is as decorator (see http://www.python.org/dev/peps/pep-0318).
+
+     Example of usage:
+         form YCPDeclarations import YCPDeclare
+
+         @YCPDeclare("string", "int", "int")
+         def function(i, ii):
+             \"\"\" Function which returns string a accept two
+                    integers as arguments. \"\"\"
+             return str(i+ii)
+    """
+
+    # tuple of types which can be used
+    # This list must be synchronized with
+    # YCPDeclarations::_interpretType function from YCPDeclarations.h!!
+    _available_types = (
+        "any",
+        "boolean",
+        "string",
+        "integer",
+        "term",
+        "symbol",
+        "path",
+        "float",
+        "void",
+        "map",
+        "list"
+    )
+
+    def __init__(self, return_type, *params_types):
+        self._return_type = ""
+        self._params = []
+
+        self._checkTypes((return_type,) + params_types)
+
+        self._return_type = return_type
+        self._params = params_types
+
+    def __call__(self, func):
+        """ Overridden operator() """
+
+        self._checkNumParams(func, len(self._params))
+
+        _addToFunctionMap(func, self._return_type, self._params)
+        return func
+
+
+    def _checkTypes(self, types):
+        """ Check if defined types are in _available_types """
+
+        _invalid_types = []
+        for type in types:
+            if type not in self._available_types:
+                _invalid_types.append(type)
+
+        if len(_invalid_types) != 0:
+            raise Exception("Unknnown types: " + str(_invalid_types))
+
+
+    def _checkNumParams(self, func, numTypes):
+        """ Check if number of parameters equals to number of defined types """
+
+        args = len(inspect.getargspec(func)[0])
+        if args != numTypes:
+            raise Exception("Number of declared types does not match number of arguments.")
+        
+

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -53,6 +53,9 @@
 #include "yast.h"
 
 #include <iostream>
+
+#include "compat.h"
+
 #define DBG(str) \
     std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
     std::cerr.flush()

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -1,0 +1,479 @@
+/*---------------------------------------------------------------------\
+|								       |
+|			__   __	  ____ _____ ____		       |
+|			\ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      YPython.cc
+
+
+
+/-*/
+
+#include <Python.h>
+#include <stdlib.h>
+#include <list>
+#include <iosfwd>
+#include <sstream>
+#include <iomanip>
+
+
+
+
+#define y2log_component "Y2Python"
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+
+#include <YPython.h>
+#include <ycp/YCPValue.h>
+#include <ycp/YCPBoolean.h>
+#include <ycp/YCPByteblock.h>
+#include <ycp/YCPFloat.h>
+#include <ycp/YCPInteger.h>
+#include <ycp/YCPList.h>
+#include <ycp/YCPMap.h>
+#include <ycp/YCPPath.h>
+#include <ycp/YCPString.h>
+#include <ycp/YCPSymbol.h>
+#include <ycp/YCPTerm.h>
+#include <ycp/YCPVoid.h>
+#include <ycp/YCPCode.h>
+#include <ycp/YCPExternal.h>
+#include <ycp/Point.h>
+
+#include "YPythonNamespace.h"
+#include "ytypes.h"
+#include "yast.h"
+
+#include <iostream>
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+YPython * YPython::_yPython = 0;
+
+PyObject * YPython::_pMainDicts = NULL;
+
+YPython::YPython(){}
+
+
+YPython::~YPython(){}
+
+
+/**
+ * return static _yPython
+ **/
+
+YPython *
+YPython::yPython()
+{
+    if ( ! _yPython )
+	_yPython = new YPython();
+
+    return _yPython;
+}
+
+/**
+ * return static _pMainDicts
+ **/
+
+PyObject* 
+YPython::pMainDicts()
+{
+
+    return _pMainDicts;
+}
+
+/**
+ * "static" destructor
+ **/
+
+
+YCPValue
+YPython::destroy()
+{
+    y2milestone( "Shutting down embedded Python interpreter." );
+
+    if ( _yPython )
+	delete _yPython;
+
+    _yPython = 0;
+    //Py_Finalize();
+    return YCPVoid();
+}
+
+
+
+/**
+ * Loads a module.
+ **/
+YCPValue
+YPython::loadModule(string module)
+{
+    string path;
+    string module_name;
+    PyObject* pModuleName;
+    size_t found;
+    PyObject* pMain;
+
+    //found last "/" in path
+    found = module.find_last_of("/");
+    //extract directory from path module
+    path = module.substr(0,found+1);
+    //extract module name from path
+    module_name = module.substr(found+1);
+    //delete last 3 chars from module name ".py"
+    module_name.erase(module_name.size()-3); //delete ".py"
+
+    //initialize python and set the path where are python modules
+    if (!Py_IsInitialized()) {
+       setenv("PYTHONPATH", path.c_str(), 1);       
+       Py_Initialize();
+       if (!YPython::_pMainDicts)
+          YPython::_pMainDicts = PyDict_New();
+    }
+
+    if (!YPython::_pMainDicts)
+       YPython::_pMainDicts = PyDict_New();
+    //create python string for name of module 
+    pModuleName = PyString_FromString(module_name.c_str());
+    //check if dictionary contain "dictionary" for module
+    if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
+       pMain = PyImport_ImportModule(module_name.c_str());
+       if (pMain == NULL){
+           y2error("Can't import module %s", module_name.c_str());
+
+           if (PyErr_Occurred() != NULL){
+              //string err = PyErrorHandler();
+              y2error("Python error: %s", PyErrorHandler().c_str());
+               //PyErr_Print();
+           }
+
+           return YCPError("The module was not imported");
+       }
+
+       int ret = PyDict_SetItem(YPython::_pMainDicts, pModuleName, PyModule_GetDict(pMain));
+       if (ret != 0)
+          return YCPError("The module was not imported");
+    } else {
+
+       //return YCPError("The module is imported");
+       y2error("The module is imported");
+       return YCPVoid();
+    }
+
+
+    return YCPVoid();
+ 
+}
+
+/**
+ * evaluate of function from python
+ * @param string name of module
+ * @param string name of function
+ * @param bool is it method? TODO !!
+ * @param YCPList argumnets from YCP to python function(0 - dummy)
+ * @return YCPValue return value from python's function
+ **/
+YCPValue
+YPython::callInner (string module, string function, bool method,
+		  YCPList argList)
+{
+    PyObject* pMainDict;  // dictionary of module
+    PyObject* pFunc;      // function from dictionary
+    PyObject* pArgs = NULL;      // tuple object of argument for function
+    PyObject* pReturn;    // return value from python
+    YCPValue result = YCPNull ();
+
+    // obtain correct dictionary for module
+    pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),module.c_str());
+
+    // obtain function from dictionary
+    if (PyDict_Contains(pMainDict,PyString_FromString(function.c_str())))
+       pFunc = PyDict_GetItemString(pMainDict, function.c_str());
+	else {
+	   y2error("Function %s is not found.", function.c_str());
+	   return result;
+	}
+
+    if (argList->size() !=0)
+       pArgs = PyTuple_New(argList->size()-1);
+
+    // Parsing argumments
+    PyObject *pArg;
+
+    for ( int i=1; i < argList->size(); i++ ) {
+        pArg = ycp_to_pyval(argList->value(i));
+        PyTuple_SetItem(pArgs,i-1, pArg);
+    }
+
+    // calling function from python
+    if (PyCallable_Check(pFunc))
+       pReturn = PyObject_Call(pFunc, pArgs, NULL);
+	else {
+	   y2error("Function %s is not callable.", function.c_str());
+	   return result;
+	}
+    // delete arguments
+    Py_CLEAR(pArgs);
+
+    // convert python value to YCPValue
+    if (pReturn)
+        result = pyval_to_ycp(pReturn); // create YCP value
+    else{
+        y2error("PyObject_CallObject(pFunc, pArgs) failed!");
+        if (PyErr_Occurred() != NULL){
+           y2error("Python error: %s", PyErrorHandler().c_str());
+           //PyErr_Print();
+        }
+    }
+    // delete pReturn
+    Py_CLEAR(pReturn);
+
+    if (result.isNull ()) {
+       result = YCPVoid ();
+    }
+
+    return result;
+}
+
+
+/**
+ * Find function in Global Dictionary
+ * confirm if function is from imported module or not
+ * return 1 if module is in dictionary and function too
+ * retrun 0 if module is in dictionary and function not
+ * return -1 if missing both (module and dinctionary)
+**/
+
+int YPython::findModuleFuncInDict(string module, string function) {
+
+    PyObject * pModuleName = PyString_FromString(module.c_str());
+    if (_pMainDicts==NULL)
+       return -1;
+    if (PyDict_Contains(_pMainDicts, pModuleName)) {
+
+       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+       if (PyDict_Contains(pMainDict, PyString_FromString(function.c_str())))
+          return 1;
+       else
+          return 0;
+
+    } else {
+
+       return -1;
+    }
+
+}
+
+/**
+  * Adding module name and function into 
+  * global dictionary 
+  * (necessary for calling python function via reference)
+ **/
+bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* function) {
+
+  
+    PyObject * pModuleName = PyString_FromString(module.c_str());
+    //check if dictionary contain "dictionary" for module
+
+    if (_pMainDicts==NULL) {
+       _pMainDicts = PyDict_New();
+    }
+
+    if (PyDict_Contains(_pMainDicts, pModuleName)) {       
+       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+
+       if (PyDict_Contains(pMainDict, PyString_FromString(fun_name.c_str()))) {
+	  return true;
+
+       } else {
+          //PyObject * newDict = PyDict_New();
+          if (PyDict_SetItemString(pMainDict, fun_name.c_str(), function) < 0) {
+             y2error("Adding new function %s to local dictionary", fun_name.c_str());
+             return false;
+          }
+
+          if (PyDict_DelItemString(_pMainDicts, module.c_str()) <0) {
+             y2error("Deleting local dictionary %s from global dictionary failed", module.c_str());
+             return false;
+          }
+
+          if (PyDict_SetItemString(_pMainDicts, module.c_str(), pMainDict) <0) {
+             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+             return false;
+          }
+
+          return true;
+       }
+    } else {
+       PyObject * newDict = PyDict_New();
+
+       if (PyDict_SetItemString(newDict, fun_name.c_str(), function) < 0) {
+             y2error("Adding new function %s to local dictionary", fun_name.c_str());
+             return false;
+       }       
+
+       if (PyDict_SetItemString(_pMainDicts, module.c_str(), newDict) <0) {
+             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+             return false;
+       }
+
+       return true;
+    }
+}
+
+YCPValue YPython::findSymbolEntry(Y2Namespace *ns, string module, string function) {
+
+  if (ns) {
+     TableEntry *sym_te = ns->table ()->find (function.c_str());
+
+     if (sym_te == NULL) {
+	y2error ("No such symbol %s::%s", module.c_str(), function.c_str());
+	return YCPNull();
+     }
+
+     SymbolEntryPtr sym_entry = sym_te->sentry();
+     //cout << "entry" << sym_entry->toString()<< endl;
+     return YCPReference(sym_entry);
+
+  } else {
+     y2error("Creating/Importing namespace for function %s failed", function.c_str());
+     return YCPNull();
+  }
+}
+
+/**
+  * Convert Python Function to YCPCode.
+  * 
+  * @param pointer to python function
+  * @return YCPReference - Referecne
+ **/
+
+YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
+    
+    PyObject *fun_code = PyFunction_GetCode(pyFun);
+    string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+    string file_path = PyString_AsString(((PyCodeObject *) fun_code)->co_filename);
+    //int no_args = ((PyCodeObject *) fun_code)->co_argcount;
+
+    //found last "/" in path
+    size_t found = file_path.find_last_of("/");
+    //extract module name from path
+    string module_name = file_path.substr(found+1);
+    //delete last 3 chars from module name ".py"
+    module_name.erase(module_name.size()-3);
+
+    int find = findModuleFuncInDict(module_name, fun_name);
+  
+    FunctionTypePtr sym_tp;
+    Y2Namespace *ns;
+
+    //namespace exist and includes function
+    if (find == 1) {
+       ns = getNs (module_name.c_str());
+
+       return findSymbolEntry(ns, module_name, fun_name);
+
+    //namespace exist but doesn't include function
+    } else if (find ==0) {
+       addModuleAndFunction(module_name, fun_name, pyFun);
+
+       ns = getNs (module_name.c_str());
+
+       if (ns) {
+
+          SymbolEntry *result = ((YPythonNamespace *)ns)->AddFunction(pyFun);
+          if (result)
+             return YCPReference(result);
+          else {
+             y2error("Adding function %s to namespace %s failed", fun_name.c_str(), module_name.c_str());
+             return YCPNull();
+          }
+             
+       } else {
+          y2error("Importing namespace %s for function %s failed",
+                  module_name.c_str(), fun_name.c_str());
+          return YCPNull();
+       }
+
+    //namespace and function don't exist
+    } else {
+
+       addModuleAndFunction(module_name, fun_name, pyFun);
+       ns = new YPythonNamespace(module_name, pyFun);
+
+       //register new namespace
+       Import import(module_name, ns);
+
+       return findSymbolEntry(ns, module_name, fun_name);
+
+    }
+
+    return YCPNull();
+}
+
+
+
+string YPython::PyErrorHandler() {
+   /* process Python-related errors */
+   /* call after Python API raises an exception */
+ 
+   PyObject *errobj, *errdata, *errtraceback, *pystring;
+
+   string result = "error type: ";
+   /* get latest python exception info */
+   PyErr_Fetch(&errobj, &errdata, &errtraceback);
+ 
+   pystring = NULL;
+   if (errobj != NULL &&
+      (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_type, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+      result += "<unknown exception type>";
+   Py_XDECREF(pystring);
+   result +="; error value: ";
+
+   pystring = NULL;
+   if (errdata != NULL &&
+      (pystring = PyObject_Str(errdata)) != NULL &&
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_info, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+       //strcpy(save_error_info, "<unknown exception data>");
+      result += "<unknown exception value>";
+   Py_XDECREF(pystring);
+
+   result +="; error traceback: ";
+
+   pystring = NULL;
+   if (errdata != NULL &&
+      (pystring = PyObject_Str(errtraceback)) != NULL &&
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_info, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+       //strcpy(save_error_info, "<unknown exception data>");
+      result += "<unknown exception traceback>";
+   Py_XDECREF(pystring);
+   //printf("%s\n%s\n", save_error_type, save_error_info);
+   Py_XDECREF(errobj);
+   Py_XDECREF(errdata);         /* caller owns all 3 */
+   Py_XDECREF(errtraceback);    /* already NULL'd out */
+   return result;
+
+}
+

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -97,6 +97,11 @@ public:
      **/
     static string PyErrorHandler();
 
+    /**
+     * Prepare YCPReference for calling python function in YCP via reference
+     **/
+    YCPValue fromPythonFunToReference (PyObject* pyFun);
+
 private:
 
     /**
@@ -157,12 +162,6 @@ private:
      * Convert a YCPList to a Python tuple.
      **/
     PyObject* fromYCPTermToPythonTerm (YCPValue ycp_Term);
-
-    /**
-     * Prepare YCPReference for calling python function in YCP via reference
-     **/
-    YCPValue fromPythonFunToReference (PyObject* pyFun);
-
 
     /**
      * Function find in namespace function and return symbol entry

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -1,0 +1,191 @@
+/*-----------------------------------------------------------*- c++ -*-\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      YPython.h
+
+
+/-*/
+
+
+#ifndef YPython_h
+#define YPython_h
+
+#include <Python.h>
+
+#include <ycp/YCPList.h>
+#include <ycp/YCPValue.h>
+#include <ycp/Type.h>
+#include <ycp/YCPCode.h>
+#include <ycp/YCode.h>
+
+
+
+class YPython
+{
+public:
+
+    /**
+     * Load a Python module - equivalent to "use" in Python.
+     *
+     * Returns a YCPError on failure, YCPVoid on success.
+     **/
+    static YCPValue loadModule(string module);
+
+    /**
+     * Access the static (singleton) YPython object. Create it if it isn't
+     * created yet.
+     *
+     * Returns 0 on error.
+     **/
+    static YPython * yPython();
+
+    /**
+     * Access the static _pMainDicts
+     * 
+     **/
+
+    PyObject* pMainDicts();
+
+    /**
+     * static _pMainDicts includes dictionaries of all imported python modules
+     * 
+     **/
+
+    static PyObject* _pMainDicts;
+
+    /**
+     * Destroy the static (singleton) YPython object and unload the embedded Python
+     * interpreter.
+     *
+     * Returns YCPVoid().
+     **/
+    static YCPValue destroy();
+
+    /**
+     * Generic Python call.
+     **/
+    YCPValue callInner (string module, string function, bool method,
+			YCPList argList);
+    
+    static YPython * _yPython;
+
+
+    /**
+     * Transform Python type to YCP type and return new YCPValue built
+     * from python object.
+     */
+    YCPValue PythonTypeToYCPType(PyObject*);
+
+    /**
+     * Transform YCP type to Python type and return reference to new
+     * Python object.
+     */
+    PyObject *YCPTypeToPythonType(YCPValue);
+
+   /**
+     * Handler for python errors, info will be saved into  yast logs
+     * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
+     **/
+    static string PyErrorHandler();
+
+private:
+
+    /**
+     * Find function in Global Dictionary
+     * confirm if function is from imported module or not
+     * return 1 if module is in dictionary and function too
+     * retrun 0 if module is in dictionary and function not
+     * return -1 if missing both (module and dinctionary)
+     **/
+
+    int findModuleFuncInDict(string module, string function);
+
+   /**
+     * Adding module name and function into 
+     * global dictionary 
+     * (necessary for calling python function via reference)
+     **/
+    bool addModuleAndFunction(string module, string fun_name, PyObject* function);
+
+
+    /**
+     * Convert a Python list to a YCPList.
+     **/
+    YCPList fromPythonListToYCPList (PyObject* pPythonList);
+
+    /**
+     * Convert a YCPList to a Python list.
+     **/
+    PyObject* fromYCPListToPythonList (YCPValue ycp_List);
+
+    /**
+     * Convert a Python Dictionary to a YCPMap.
+     **/
+    YCPMap fromPythonDictToYCPMap (PyObject* pPythonDict);
+
+
+    /**
+     * Convert a YCPMap to a Python Dictionary.
+     **/
+    PyObject* fromYCPMapToPythonDict (YCPValue ycp_Map);
+
+    /**
+     * Convert a Python Tuple to YCPList
+     **/
+    YCPList fromPythonTupleToYCPList (PyObject* pPythonTuple);
+
+    /**
+     * Convert a YCPList to a Python tuple.
+     **/
+    PyObject* fromYCPListToPythonTuple (YCPValue ycp_List);
+
+    /**
+     * Convert a Python Tuple to YCPList
+     **/
+    YCPTerm fromPythonTermToYCPTerm (PyObject* pPythonTerm);
+
+    /**
+     * Convert a YCPList to a Python tuple.
+     **/
+    PyObject* fromYCPTermToPythonTerm (YCPValue ycp_Term);
+
+    /**
+     * Prepare YCPReference for calling python function in YCP via reference
+     **/
+    YCPValue fromPythonFunToReference (PyObject* pyFun);
+
+
+    /**
+     * Function find in namespace function and return symbol entry
+     **/
+    YCPValue findSymbolEntry(Y2Namespace *ns, string module, string function);
+
+protected:
+
+    /**
+     * Protected constructor. Use one of the static methods rather than
+     * instantiate an object of this class yourself.
+     **/
+    YPython();
+
+    /**
+     * Destructor.
+     **/
+    ~YPython();
+
+    
+
+
+};
+
+
+#endif	// YPython_h

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -1,0 +1,395 @@
+/**
+ * 
+ *
+ * This is the path from YCP to Python.
+ */
+
+#include <Python.h>
+#include "YPythonNamespace.h"
+
+#define y2log_component "Y2PythonNamespace"
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+#include <ycp/YCPElement.h>
+#include <ycp/Type.h>
+#include <ycp/YCPVoid.h>
+
+#include <YPython.h>
+#include <stdio.h>
+
+#include "YCPDeclarations.h"
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+
+
+/**
+ * The definition of a function that is implemented in Perl
+ */
+class Y2PythonFunctionCall : public Y2Function
+{
+    //! module name
+    string m_module_name;
+    //! function name, excluding module name
+    string m_local_name;
+    //! function type
+    constFunctionTypePtr m_type;
+    //! data prepared for the inner call
+    YCPList m_call;
+
+public:
+    Y2PythonFunctionCall (const string &module_name,
+			 const string &local_name,
+                         constFunctionTypePtr function_type
+	) :
+	m_module_name (module_name),
+	m_local_name (local_name),
+	m_type (function_type)
+	{
+	    // placeholder, formerly function name
+	    m_call->add (YCPVoid ());
+	}
+
+    //! if true, the python function is passed the module name
+    virtual bool isMethod () = 0;
+
+    //! called by YEFunction::evaluate
+    virtual YCPValue evaluateCall ()
+    {
+	return YPython::yPython()->callInner (
+	    m_module_name, m_local_name, isMethod (),
+	    m_call);
+    }
+    
+       /**
+     * Attaches a parameter to a given position to the call.
+     * @return false if there was a type mismatch
+     */
+    virtual bool attachParameter (const YCPValue& arg, const int position)
+    {
+	m_call->set (position+1, arg);
+	return true;
+    }
+
+    /**
+     * What type is expected for the next appendParameter (val) ?
+     * (Used when calling from Perl, to be able to convert from the
+     * simple type system of Perl to the elaborate type system of YCP)
+     * @return Type::Any if number of parameters exceeded
+     */
+    virtual constTypePtr wantedParameterType () const
+    {
+	// -1 for the function name
+	int params_so_far = m_call->size ()-1;
+	return m_type->parameterType (params_so_far);
+    }
+     
+    /**
+     * Appends a parameter to the call.
+     * @return false if there was a type mismatch
+     */
+    virtual bool appendParameter (const YCPValue& arg)
+    {
+	m_call->add (arg);
+	return true;
+    }
+
+    /**
+     * Signal that we're done adding parameters.
+     * @return false if there was a parameter missing
+     */
+    virtual bool finishParameters () { return true; }
+
+
+    virtual bool reset ()
+    {
+	m_call = YCPList ();
+	// placeholder, formerly function name
+	m_call->add (YCPVoid ());
+	return true;
+    }
+
+    /**
+     * Something for remote namespaces
+     */
+    virtual string name () const { return m_local_name; }
+};
+
+class Y2PythonSubCall : public Y2PythonFunctionCall {
+public:
+    Y2PythonSubCall (const string &module_name,
+		     const string &local_name,
+		     constFunctionTypePtr function_type 
+	) :
+	Y2PythonFunctionCall (module_name, local_name, function_type)
+	{}
+    virtual bool isMethod () { return false; }
+};
+
+class Y2PythonMethodCall : public Y2PythonFunctionCall {
+public:
+    Y2PythonMethodCall (const string &module_name,
+			const string &local_name,
+                        constFunctionTypePtr function_type
+	) :
+	Y2PythonFunctionCall (module_name, local_name, function_type)
+	{}
+    virtual bool isMethod () { return true; }
+};
+
+
+
+YPythonNamespace::YPythonNamespace (string name)
+    : m_name (name),
+      m_all_methods (true)
+{
+
+  //Objects for Python API
+  PyObject* pMainDict;    //global dictionary of imported module
+  PyObject* pFunc;        //pionter for function from python
+  PyObject* item;         //item from dictionary
+  PyObject * fun_names;   //list of keys from dictionary (YPython::yPython()->pMain())
+  PyObject * fun_code;    //code of function
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  //YCPDeclarations *decl = new YCPDeclarations();
+  
+  FunctionTypePtr sym_tp;
+  std::vector<constTypePtr> list_of_types;
+  int tmp;
+
+
+  int num_fun_names = 0; //number of keys from dictionary
+  int count = 0;         // position. arbitrary numbering
+  long num = 0;          //number of function arguments
+
+  //obtain main dictionary of globals variables
+  pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),name.c_str());
+  if (pMainDict == NULL){
+      y2error("Can't load module %s", name.c_str());
+      return;
+  }
+
+  //keys from dictionary
+  fun_names = PyDict_Keys(pMainDict);
+
+  //number of symbols
+  num_fun_names = PyList_Size(fun_names);
+  //check each symbol and try to find function names
+  for (int i = 0; i < num_fun_names; i++) {
+    //y2milestone ("YPythonNamespace iteration %d from all %d", i, num_fun_names);
+    item = PyList_GetItem(fun_names, i); /* Can’t fail */
+    //y2milestone ("YPythonNamespace item: %s", PyString_AsString(item));
+    if (!PyString_Check(item)) continue; /* Skip non-string */
+    //y2milestone ("item: %s", PyString_AsString(item));
+    pFunc = PyDict_GetItemString(pMainDict,PyString_AsString(item));    
+    //check if symbol is callable    
+
+    if (PyFunction_Check(pFunc)) {
+       fun_code = PyFunction_GetCode(pFunc);
+       num = ((PyCodeObject *) fun_code)->co_argcount;
+
+         
+       if (decl->exists((PyFunctionObject *)pFunc) 
+           && decl->numParams((PyFunctionObject *)pFunc) == num){
+
+           sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)pFunc));
+
+           list_of_types = decl->params((PyFunctionObject *)pFunc);
+           tmp = list_of_types.size();
+           for (int i=0; i < tmp; i++){
+               sym_tp->concat(list_of_types[i]);
+           }
+       }else{
+           sym_tp = new FunctionType(Type::Any);
+           //y2milestone ("Number of parameters: %d", num);
+           //add types and number of arguments into SymbolEntry table
+           for (long j = 0; j < num; j++) {
+               sym_tp->concat(Type::Any);    
+           }
+       }
+       //y2milestone ("Callable function %s", PyString_AsString(item));
+       // symbol entry for the function
+       SymbolEntry *fun_se = new SymbolEntry (
+		this,
+		count++,	         // position. arbitrary numbering. must stay consistent when?
+		PyString_AsString(item), // passed to Ustring, no need to strdup
+		SymbolEntry::c_function, 
+		sym_tp);
+       fun_se->setGlobal (true);
+
+       // enter it to the symbol table
+       enterSymbol (fun_se, 0);
+    }
+  } // end of for (int i = 0; i < num_fun_names; i++)
+
+  y2milestone ("YPythonNamespace finish");
+  
+}
+
+
+YPythonNamespace::YPythonNamespace (string name, PyObject* function)
+      : m_name (name),
+        m_all_methods (true) {
+
+
+  PyObject * fun_code;    //code of function
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  //YCPDeclarations *decl = new YCPDeclarations();
+  
+  FunctionTypePtr sym_tp;
+  std::vector<constTypePtr> list_of_types;
+  int tmp;
+
+  int count = 0;         // position. arbitrary numbering
+  long num = 0;          //number of function arguments
+
+
+  fun_code = PyFunction_GetCode(function);
+  num = ((PyCodeObject *) fun_code)->co_argcount;
+  string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+         
+  if (decl->exists((PyFunctionObject *)function) 
+      && decl->numParams((PyFunctionObject *)function) == num){
+
+     sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)function));
+
+     list_of_types = decl->params((PyFunctionObject *)function);
+     tmp = list_of_types.size();
+     for (int i=0; i < tmp; i++){
+         sym_tp->concat(list_of_types[i]);
+     }
+  } else {
+     sym_tp = new FunctionType(Type::Any);
+     //y2milestone ("Number of parameters: %d", num);
+     //add types and number of arguments into SymbolEntry table
+     for (long j = 0; j < num; j++) {
+         sym_tp->concat(Type::Any);    
+     }
+  }
+  //y2milestone ("Callable function %s", PyString_AsString(item));
+  // symbol entry for the function
+  SymbolEntry *fun_se = new SymbolEntry (
+	this,
+	count++,	         // position. arbitrary numbering. must stay consistent when?
+	fun_name.c_str(), // passed to Ustring, no need to strdup
+	SymbolEntry::c_function, 
+	sym_tp);
+  fun_se->setGlobal (true);
+
+  // enter it to the symbol table
+  enterSymbol (fun_se, 0);
+
+
+  y2milestone ("(special) YPythonNamespace finish");
+
+}
+
+SymbolEntry * YPythonNamespace::AddFunction (PyObject* function) {
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  int tmp;
+  std::vector<constTypePtr> list_of_types;
+  FunctionTypePtr sym_tp;
+  PyObject *fun_code = PyFunction_GetCode(function);
+  int num = ((PyCodeObject *) fun_code)->co_argcount;
+  string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+         
+  if (decl->exists((PyFunctionObject *)function) 
+      && decl->numParams((PyFunctionObject *)function) == num){
+
+     sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)function));
+
+     list_of_types = decl->params((PyFunctionObject *)function);
+     tmp = list_of_types.size();
+     for (int i=0; i < tmp; i++){
+         sym_tp->concat(list_of_types[i]);
+     }
+  } else {
+     sym_tp = new FunctionType(Type::Any);
+     //y2milestone ("Number of parameters: %d", num);
+     //add types and number of arguments into SymbolEntry table
+     for (long j = 0; j < num; j++) {
+         sym_tp->concat(Type::Any);    
+     }
+  }
+  // symbol entry for the function
+  SymbolEntry *fun_se = new SymbolEntry (
+	this,
+	0,	        // position. arbitrary numbering. must stay consistent when?
+	fun_name.c_str(),       // passed to Ustring, no need to strdup
+	SymbolEntry::c_function, 
+	sym_tp);
+
+  fun_se->setGlobal (true);
+
+  enterSymbol (fun_se, 0);
+
+  return fun_se;
+}
+
+
+YPythonNamespace::~YPythonNamespace ()
+{
+
+
+}
+
+const string YPythonNamespace::filename () const
+{
+    // TODO improve
+    return ".../" + m_name;
+}
+
+// this is for error reporting only?
+string YPythonNamespace::toString () const
+{
+    y2error ("TODO");
+    return "{\n"
+	"/* this namespace is provided in Python */\n"
+	"}\n";
+}
+
+// called when running and the import statement is encountered
+// does initialization of variables
+// constructor is handled separately after this
+YCPValue YPythonNamespace::evaluate (bool cse)
+{
+    // so we don't need to do anything
+    y2debug ("Doing nothing");
+    return YCPNull ();
+}
+
+
+// It seems that this is the standard implementation. why would we
+// ever want it to be different?
+Y2Function* YPythonNamespace::createFunctionCall (const string name, constFunctionTypePtr required_type)
+{
+    y2debug ("Python creating function call for %s", name.c_str ());
+    //TableEntry *func_te = table ()->find (name.c_str (), SymbolEntry::c_function);
+    TableEntry *func_te = table ()->find (name.c_str ());
+
+    if (func_te)
+    {
+        //cout << "namespace: " << m_name << " function: " << name << endl;
+	constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
+	if (m_all_methods)
+	{
+	    return new Y2PythonMethodCall (m_name, name, t);
+	}
+	else
+	{
+	    return new Y2PythonSubCall (m_name, name, t);
+	}
+    }
+    
+    //cout << "namespace: " << m_name << " function: " << name << endl;
+    y2error ("No such function %s", name.c_str ());
+    return NULL;
+}

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -1,0 +1,53 @@
+// -*- c++ -*-
+#include <Python.h>
+#include <y2/Y2Namespace.h>
+#include <y2/Y2Function.h>
+#include <ycp/YStatement.h>
+
+/**
+ * YaST interface to a Python module
+ */
+class YPythonNamespace : public Y2Namespace
+{
+private:
+    string m_name;		//! this namespace's name, eg. XML::Writer
+    bool m_all_methods;		//! add the class name to all calls
+public:
+
+    /**
+     * Construct an interface. The module must be already loaded
+     * @param name eg "XML::Writer"
+     */
+    YPythonNamespace (string name);
+
+    /**
+     * Construct an interface. The module must be already loaded
+     * special contruct for calling python function such as reference
+     * @param name eg "XML::Writer"
+     * @param function function defined in python
+     */
+    YPythonNamespace (string name, PyObject* function);
+
+    /**
+     * Add new function into namespace
+     * @param Y2Namespace pointer to namespace for adding function
+     * @param PyObject pointer to function
+     * @return SymbolEntry pointer to added symbol entry else NULL (if failed)
+     */
+    SymbolEntry * AddFunction (PyObject* function);
+
+    virtual ~YPythonNamespace ();
+
+    //! what namespace do we implement
+    virtual const string name () const { return m_name; }
+    //! used for error reporting
+    virtual const string filename () const;
+
+    //! unparse. useful  only for YCP namespaces??
+    virtual string toString () const;
+    //! called when evaluating the import statement
+    // constructor is handled separately
+    virtual YCPValue evaluate (bool cse = false);
+
+    virtual Y2Function* createFunctionCall (const string name, constFunctionTypePtr requiredType);
+};

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,19 @@
+/* Compatibility macros for Python 3 */
+#if PY_VERSION_HEX >= 0x03000000
+
+#define PyClass_Check(obj) PyObject_IsInstance(obj, (PyObject *)&PyType_Type)
+#define PyInt_Check(x) PyLong_Check(x)
+#define PyInt_AsLong(x) PyLong_AsLong(x)
+#define PyInt_FromLong(x) PyLong_FromLong(x)
+#define PyInt_FromSize_t(x) PyLong_FromSize_t(x)
+#define PyString_Check(name) PyBytes_Check(name)
+#define PyString_FromString(x) PyUnicode_FromString(x)
+#define PyString_Format(fmt, args)  PyUnicode_Format(fmt, args)
+#define PyString_AsString(str) PyBytes_AsString(str)
+#define PyString_Size(str) PyBytes_Size(str)    
+#define PyString_InternFromString(key) PyUnicode_InternFromString(key)
+#define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
+#define PyString_AS_STRING(x) PyUnicode_AS_STRING(x)
+#define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
+
+#endif

--- a/src/yast-core.i
+++ b/src/yast-core.i
@@ -13,6 +13,7 @@ using namespace std;
 
 %{
 #include "yast.h"
+#include "YPython.h"
 #include "YPythonCode.h"
 #include <ycp/YCPByteblock.h>
 %}

--- a/src/yast.cpp
+++ b/src/yast.cpp
@@ -10,7 +10,7 @@ bool widget_names()
     return true;
 }
 
-static Y2Namespace * getNs(const char * ns_name)
+Y2Namespace * getNs(const char * ns_name)
 {
     Import import(ns_name); // has a static cache
     Y2Namespace *ns = import.nameSpace();

--- a/src/yast.h
+++ b/src/yast.h
@@ -36,4 +36,4 @@ PyObject* import_module(const string & ns_name);
 
 bool widget_names();
 YCPValue _SCR_Run(char *function, YCPList args);
-
+Y2Namespace * getNs(const char * ns_name);

--- a/src/yast.py
+++ b/src/yast.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import ycpbuiltins
 from ycp import Symbol, List, String, Integer, Boolean, Float, Code, Map, Byteblock, Path, Void
+from YCPDeclarations import YCPDeclare as Declare
 
 def import_module(module):
     from ycp import import_module as ycp_import_module

--- a/src/ytypes.i
+++ b/src/ytypes.i
@@ -45,7 +45,7 @@ YCPValue pyval_to_ycp(PyObject *input)
         }
     }
     if (PyFunction_Check(input))
-        return YCPCode(new YPythonCode(PyTuple_Pack(1, input)));
+        return YPython::yPython()->fromPythonFunToReference(input);
     if (PyDict_Check(input)) {
         YCPMap m;
         if (PyDict_Size(input) == 0)


### PR DESCRIPTION
Importing python modules from ruby/perl is now possible using this old code that's been re-integrated (and builds via python3).