### PR TITLE
Define yast._() as an alias to gettext()

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan  9 14:52:04 UTC 2019 - dmulder@suse.com
+
+- Define yast._() as an alias to gettext(); (bsc#1121106).
+
+-------------------------------------------------------------------
 Tue Jan  8 20:29:50 UTC 2019 - dmulder@suse.com
 
 - Provide textdomain() and gettext() functions for

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %endif
 
 Name:           yast2-python-bindings
-Version:        4.0.6
+Version:        4.0.7
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/src/yast.py.in
+++ b/src/yast.py.in
@@ -3,6 +3,7 @@ import ycpbuiltins
 from ycp import Symbol, List, String, Integer, Boolean, Float, Code, Map, Byteblock, Path, Void
 
 from gettext import gettext
+globals()['_'] = gettext
 def textdomain(domain):
     from gettext import bindtextdomain, textdomain as gt_textdomain
     bindtextdomain(domain, '@DATADIR@/YaST2/locale')


### PR DESCRIPTION
This more closely mimics the ruby/perl syntax:

from yast import textdomain, _
textdomain('mymodule')
print(_('translatable text here'))