### PR TITLE
Forward port old bindings code which handled python import from ruby/perl, etc

### DIFF
--- a/configure.in.in
+++ b/configure.in.in
@@ -11,6 +11,7 @@
 
 AC_ARG_ENABLE([python3], AS_HELP_STRING([--enable-python3], [Enable python3 build]))
 
+AM_CONDITIONAL([HAVE_PY3], [test "x$enable_python3" = "xyes"])
 if test "x$enable_python3" = "xyes"; then
     AM_PATH_PYTHON([3.4])
 else

--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan  9 18:37:13 UTC 2019 - dmulder@suse.com
+
+- Forward port python import capability.
+
+-------------------------------------------------------------------
 Wed Jan  9 14:52:04 UTC 2019 - dmulder@suse.com
 
 - Define yast._() as an alias to gettext(); (bsc#1121106).

--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,7 +1,10 @@
 -------------------------------------------------------------------
-Wed Jan  9 18:37:13 UTC 2019 - dmulder@suse.com
+Fri Jan 18 17:39:23 UTC 2019 - dmulder@suse.com, nopower@suse.com
 
-- Forward port python import capability.
+- Forward port python import capability, with improvements and code
+  cleanup.
+- Add pydocs to yast python
+- Improve building/packaging of python2/3
 
 -------------------------------------------------------------------
 Wed Jan  9 14:52:04 UTC 2019 - dmulder@suse.com

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %endif
 
 Name:           yast2-python-bindings
-Version:        4.0.7
+Version:        4.0.8
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-python-bindings
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 
@@ -100,18 +100,17 @@ make
 %yast_install
 rm %{buildroot}/%{python_sitelib}/*.pyc
 rm %{buildroot}/%{python_sitelib}/*.pyo
-rm %{buildroot}/%{python_sitearch}/*.la
 rm %{buildroot}/%{yast_plugindir}/*.la
+%__mkdir_p %{buildroot}/%{python_sitearch}/
+%__ln_s %{yast_plugindir}/libpy2lang_python.so %{buildroot}/%{python_sitearch}/_ycp.so
 %if %{with_python3}
 %__mkdir_p %{buildroot}/%{python3_sitelib}/
 %__install -m 0644 %{builddir}/python3/*.py %{buildroot}/%{python3_sitelib}/
 %__mkdir_p %{buildroot}/%{python3_sitearch}/
-%__install -m 0755 %{builddir}/python3/_ycp.so* %{buildroot}/%{python3_sitearch}/
-%__ln_s %{python3_sitearch}/_ycp.so.0.0.0 %{buildroot}/%{python3_sitearch}/_ycp.so.0
-%__ln_s %{python3_sitearch}/_ycp.so.0.0.0 %{buildroot}/%{python3_sitearch}/_ycp.so
 %__install -m 0755 %{builddir}/python3/libpy2lang_python.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so.0.0.0
 %__ln_s %{yast_plugindir}/libpy2lang_python3.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so
 %__ln_s %{yast_plugindir}/libpy2lang_python3.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so.0
+%__ln_s %{yast_plugindir}/libpy2lang_python3.so %{buildroot}/%{python3_sitearch}/_ycp.so
 %endif
 
 %if %{with_python3}
@@ -119,7 +118,7 @@ rm %{buildroot}/%{yast_plugindir}/*.la
 %defattr (-, root, root)
 %doc %{yast_docdir}
 %{python3_sitelib}/*.py
-%{python3_sitearch}/_ycp.so*
+%{python3_sitearch}/_ycp.so
 %{yast_plugindir}/libpy2lang_python3.so.*
 %{yast_plugindir}/libpy2lang_python3.so
 %endif
@@ -128,7 +127,7 @@ rm %{buildroot}/%{yast_plugindir}/*.la
 %defattr (-, root, root)
 %doc %{yast_docdir}
 %{python_sitelib}/*.py
-%{python_sitearch}/_ycp.so*
+%{python_sitearch}/_ycp.so
 %{yast_plugindir}/libpy2lang_python.so.*
 %{yast_plugindir}/libpy2lang_python.so
 %license COPYING

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -82,36 +82,24 @@ and also Python scripts can use YaST agents, APIs and modules.
 
 %build
 make -f Makefile.cvs all
-
 %if %{with_python3}
-%configure --enable-python3
-make
-mkdir -p %{builddir}/python3
-%__cp -d src/*.py %{builddir}/python3
-%__cp -d src/.libs/*.so.0.0.0 %{builddir}/python3
-%__cp -d src/*.la %{builddir}/python3
-make clean
+mkdir py3 && pushd py3
+%__ln_s ../configure configure
+%{configure} --enable-python3
+%make_build
+popd
 %endif
-
-%configure
-make
+mkdir py2 && pushd py2
+%__ln_s ../configure configure
+%{configure}
+%make_build
+popd
 
 %install
-%yast_install
-rm %{buildroot}/%{python_sitelib}/*.pyc
-rm %{buildroot}/%{python_sitelib}/*.pyo
-rm %{buildroot}/%{yast_plugindir}/*.la
-%__mkdir_p %{buildroot}/%{python_sitearch}/
-%__ln_s %{yast_plugindir}/libpy2lang_python.so %{buildroot}/%{python_sitearch}/_ycp.so
 %if %{with_python3}
-%__mkdir_p %{buildroot}/%{python3_sitelib}/
-%__install -m 0644 %{builddir}/python3/*.py %{buildroot}/%{python3_sitelib}/
-%__mkdir_p %{buildroot}/%{python3_sitearch}/
-%__install -m 0755 %{builddir}/python3/libpy2lang_python.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so.0.0.0
-%__ln_s %{yast_plugindir}/libpy2lang_python3.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so
-%__ln_s %{yast_plugindir}/libpy2lang_python3.so.0.0.0 %{buildroot}/%{yast_plugindir}/libpy2lang_python3.so.0
-%__ln_s %{yast_plugindir}/libpy2lang_python3.so %{buildroot}/%{python3_sitearch}/_ycp.so
+%make_install -C py3
 %endif
+%make_install -C py2
 
 %if %{with_python3}
 %files -n yast2-python3-bindings
@@ -121,6 +109,10 @@ rm %{buildroot}/%{yast_plugindir}/*.la
 %{python3_sitearch}/_ycp.so
 %{yast_plugindir}/libpy2lang_python3.so.*
 %{yast_plugindir}/libpy2lang_python3.so
+%exclude %dir %{python3_sitelib}/__pycache__
+%exclude %{python3_sitelib}/__pycache__/*.pyc
+%exclude %{python3_sitelib}/__pycache__/*.pyo
+%exclude %{yast_plugindir}/libpy2lang_python3.la
 %endif
 
 %files -n yast2-python-bindings
@@ -131,5 +123,8 @@ rm %{buildroot}/%{yast_plugindir}/*.la
 %{yast_plugindir}/libpy2lang_python.so.*
 %{yast_plugindir}/libpy2lang_python.so
 %license COPYING
+%exclude %{python_sitelib}/*.pyc
+%exclude %{python_sitelib}/*.pyo
+%exclude %{yast_plugindir}/libpy2lang_python.la
 
 %changelog

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 BUILT_SOURCES = ycp.py yast.py
-ycp.py yast-core_wrap.cxx: yast-core.i ytypes.i ycp.i $(libpy2UI) YCPMap.h y2log.i yast.h ytypes.h y2log.h PythonLogger.h Y2PythonClientComponent.h YPythonCode.h Y2CCPythonClient.h
+ycp.py yast-core_wrap.cxx: yast-core.i ytypes.i ycp.i $(libpy2UI) YCPMap.h y2log.i
 	$(SWIG) $(AX_SWIG_PYTHON_OPT) -c++ -I/usr/include/YaST2 -o $@ $<
 
 yast.py: yast.py.in
@@ -9,26 +9,24 @@ yast.py: yast.py.in
 YCPMap.h:
 	sed 's/__attribute__ ((deprecated)) //g' /usr/include/YaST2/ycp/YCPMap.h > YCPMap.h
 
-python_PYTHON = ycp.py yast.py ycpbuiltins.py
+python_PYTHON = ycp.py yast.py ycpbuiltins.py YCPDeclarations.py
 
-pyexec_LTLIBRARIES = _ycp.la
+noinst_HEADERS = PythonLogger.h y2log.h yast.h YPythonCode.h ytypes.h Y2CCPythonClient.h Y2PythonClientComponent.h YCPDeclarations.h YPython.h Y2CCPython.h Y2PythonComponent.h YCPMap.h YPythonNamespace.h
 
-_ycp_la_SOURCES = yast-core_wrap.cxx yast.cpp yast-core.i ytypes.i ycp.i YPythonCode.cc PythonLogger.cc y2log.i
-noinst_HEADERS = yast.h ytypes.h y2log.h PythonLogger.h Y2PythonClientComponent.h YPythonCode.h Y2CCPythonClient.h
-
-_ycp_la_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(py2langdir)
-
-_ycp_la_LIBADD = -L$(py2langdir) -lpy2UI
-
-_ycp_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
+install-exec-hook:
+	(cd ${pyexecdir}; $(LN_S) ${py2langdir}/libpy2lang_python.so _ycp.so || echo)
+uninstall-hook:
+	(cd ${pyexecdir}; rm -f _ycp.so || echo)
 
 py2lang_LTLIBRARIES = libpy2lang_python.la
 
-libpy2lang_python_la_SOURCES = Y2PythonClientComponent.cc Y2CCPythonClient.cc
+libpy2lang_python_la_SOURCES = Y2PythonComponent.cc Y2CCPython.cc YPython.cc YPythonNamespace.cc YCPDeclarations.cc yast.cpp yast-core_wrap.cxx Y2PythonClientComponent.cc Y2CCPythonClient.cc YPythonCode.cc PythonLogger.cc
 
-libpy2lang_python_la_LDFLAGS = ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+libpy2lang_python_la_LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
 
-libpy2lang_python_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate
+libpy2lang_python_la_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+
+libpy2lang_python_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
 
 AM_CXXFLAGS = -DY2LOG=\"Python\"
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ yast.py: yast.py.in
 YCPMap.h:
 	sed 's/__attribute__ ((deprecated)) //g' /usr/include/YaST2/ycp/YCPMap.h > YCPMap.h
 
-python_PYTHON = ycp.py yast.py ycpbuiltins.py YCPDeclarations.py
+python_PYTHON = ycp.py yast.py yast_help.py ycpbuiltins.py YCPDeclarations.py
 
 noinst_HEADERS = PythonLogger.h y2log.h yast.h YPythonCode.h ytypes.h Y2CCPythonClient.h Y2PythonClientComponent.h YCPDeclarations.h YPython.h Y2CCPython.h Y2PythonComponent.h YCPMap.h YPythonNamespace.h
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,20 +13,35 @@ python_PYTHON = ycp.py yast.py ycpbuiltins.py YCPDeclarations.py
 
 noinst_HEADERS = PythonLogger.h y2log.h yast.h YPythonCode.h ytypes.h Y2CCPythonClient.h Y2PythonClientComponent.h YCPDeclarations.h YPython.h Y2CCPython.h Y2PythonComponent.h YCPMap.h YPythonNamespace.h
 
+if HAVE_PY3
+PYTHON_VERS = python3
+else
+PYTHON_VERS = python
+endif
+
 install-exec-hook:
-	(cd ${pyexecdir}; $(LN_S) ${py2langdir}/libpy2lang_python.so _ycp.so || echo)
+	(mkdir -p $(DESTDIR)/${pyexecdir}; cd $(DESTDIR)/${pyexecdir}; $(LN_S) ${py2langdir}/libpy2lang_$(PYTHON_VERS).so _ycp.so || echo)
 uninstall-hook:
-	(cd ${pyexecdir}; rm -f _ycp.so || echo)
+	(cd $(DESTDIR)/${pyexecdir}; rm -f _ycp.so || echo)
 
+SOURCES = Y2PythonComponent.cc Y2CCPython.cc YPython.cc YPythonNamespace.cc YCPDeclarations.cc yast.cpp yast-core_wrap.cxx Y2PythonClientComponent.cc Y2CCPythonClient.cc YPythonCode.cc PythonLogger.cc
+LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
+LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
+
+if HAVE_PY3
+py2lang_LTLIBRARIES = libpy2lang_python3.la
+libpy2lang_python3_la_SOURCES = $(SOURCES)
+libpy2lang_python3_la_LIBADD = $(LIBADD)
+libpy2lang_python3_la_LDFLAGS = $(LDFLAGS)
+libpy2lang_python3_la_CPPFLAGS = $(CPPFLAGS)
+else
 py2lang_LTLIBRARIES = libpy2lang_python.la
-
-libpy2lang_python_la_SOURCES = Y2PythonComponent.cc Y2CCPython.cc YPython.cc YPythonNamespace.cc YCPDeclarations.cc yast.cpp yast-core_wrap.cxx Y2PythonClientComponent.cc Y2CCPythonClient.cc YPythonCode.cc PythonLogger.cc
-
-libpy2lang_python_la_LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
-
-libpy2lang_python_la_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
-
-libpy2lang_python_la_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
+libpy2lang_python_la_SOURCES = $(SOURCES)
+libpy2lang_python_la_LIBADD = $(LIBADD)
+libpy2lang_python_la_LDFLAGS = $(LDFLAGS)
+libpy2lang_python_la_CPPFLAGS = $(CPPFLAGS)
+endif
 
 AM_CXXFLAGS = -DY2LOG=\"Python\"
 

--- a/src/Y2CCPython.cc
+++ b/src/Y2CCPython.cc
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2CCPython.cc
+
+
+/-*/
+
+#include <Python.h>
+#include "Y2CCPython.h"
+#include <ycp/pathsearch.h>
+#define y2log_component "Y2Python"
+#include <ycp/y2log.h>
+
+// This is very important: We create one global variable of
+// Y2CCPython. Its constructor will register it automatically to
+// the Y2ComponentBroker, so that will be able to find it.
+// This all happens before main() is called!
+
+Y2CCPython g_y2ccpython;
+
+Y2Component *Y2CCPython::provideNamespace (const char *name)
+{
+    y2debug ("Y2CCPython::provideNamespace %s", name);
+    if (strcmp (name, "Python") == 0)
+    {
+	// low level functions
+
+	// leave implementation to later
+	return 0;
+    }
+    else
+    {
+	// is there a python module?
+	// must be the same in Y2CCPython and Y2PythonComponent
+	string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
+	if (!module.empty ())
+	{
+	    if (!cpython)
+	    {
+		cpython = new Y2PythonComponent ();
+	    }
+	    return cpython;
+	}
+
+	// let someone else try creating the namespace
+	return 0;
+    }
+}

--- a/src/Y2CCPython.cc
+++ b/src/Y2CCPython.cc
@@ -31,28 +31,23 @@ Y2CCPython g_y2ccpython;
 Y2Component *Y2CCPython::provideNamespace (const char *name)
 {
     y2debug ("Y2CCPython::provideNamespace %s", name);
-    if (strcmp (name, "Python") == 0)
-    {
-	// low level functions
+    if (strcmp (name, "Python") == 0) {
+        // low level functions
 
-	// leave implementation to later
-	return 0;
-    }
-    else
-    {
-	// is there a python module?
-	// must be the same in Y2CCPython and Y2PythonComponent
-	string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
-	if (!module.empty ())
-	{
-	    if (!cpython)
-	    {
-		cpython = new Y2PythonComponent ();
-	    }
-	    return cpython;
-	}
+        // leave implementation to later
+        return 0;
+    } else {
+        // is there a python module?
+        // must be the same in Y2CCPython and Y2PythonComponent
+        string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
+        if (!module.empty ()) {
+            if (!cpython) {
+                cpython = new Y2PythonComponent ();
+            }
+            return cpython;
+        }
 
-	// let someone else try creating the namespace
-	return 0;
+        // let someone else try creating the namespace
+        return 0;
     }
 }

--- a/src/Y2CCPython.h
+++ b/src/Y2CCPython.h
@@ -1,0 +1,73 @@
+/*-----------------------------------------------------------*- c++ -*-\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2CCPython.h
+
+/-*/
+
+#include <Python.h>
+#ifndef _Y2CCPython_h
+#define _Y2CCPython_h
+
+#include "Y2PythonComponent.h"
+
+/**
+ * @short Y2ComponentCreator that creates Python-from-YCP bindings.
+ *
+ * A Y2ComponentCreator is an object that can create components.
+ * It receives a component name and - if it knows how to create
+ * such a component - returns a newly created component of this
+ * type. Y2CCPython can create components with the name "Python".
+ */
+class Y2CCPython : public Y2ComponentCreator
+{
+private:
+    Y2Component *cpython;
+
+public:
+    /**
+     * Creates a Python component creator
+     */
+    Y2CCPython() : Y2ComponentCreator( Y2ComponentBroker::BUILTIN ),
+	cpython (0) {};
+
+    ~Y2CCPython () {
+	if (cpython)
+	    delete cpython;
+    }
+
+    /**
+     * Returns true, since the Python component is a YaST2 server.
+     */
+    bool isServerCreator() const { return true; };
+
+    /**
+     * Creates a new Python component.
+     */
+    Y2Component *create( const char * name ) const
+    {
+	// create as many as requested, they all share the static YPython anyway
+	if ( ! strcmp( name, "python") ) return new Y2PythonComponent();
+	else return 0;
+    }
+
+    /**
+     * always returns the same component, deletes it finally
+     */
+    Y2Component *provideNamespace (const char *name);
+
+};
+
+#endif	// ifndef _Y2CCPython_h
+
+
+// EOF

--- a/src/Y2CCPython.h
+++ b/src/Y2CCPython.h
@@ -38,26 +38,34 @@ public:
      * Creates a Python component creator
      */
     Y2CCPython() : Y2ComponentCreator( Y2ComponentBroker::BUILTIN ),
-	cpython (0) {};
+        cpython (0) {};
 
-    ~Y2CCPython () {
-	if (cpython)
-	    delete cpython;
+    ~Y2CCPython ()
+    {
+        if (cpython) {
+            delete cpython;
+        }
     }
 
     /**
      * Returns true, since the Python component is a YaST2 server.
      */
-    bool isServerCreator() const { return true; };
+    bool isServerCreator() const
+    {
+        return true;
+    };
 
     /**
      * Creates a new Python component.
      */
     Y2Component *create( const char * name ) const
     {
-	// create as many as requested, they all share the static YPython anyway
-	if ( ! strcmp( name, "python") ) return new Y2PythonComponent();
-	else return 0;
+        // create as many as requested, they all share the static YPython anyway
+        if ( ! strcmp( name, "python") ) {
+            return new Y2PythonComponent();
+        } else {
+            return 0;
+        }
     }
 
     /**

--- a/src/Y2PythonComponent.cc
+++ b/src/Y2PythonComponent.cc
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2PythonComponent.cc
+
+
+
+/-*/
+
+#define y2log_component "Y2Python"
+#include <Python.h>
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+#include "Y2PythonComponent.h"
+
+//XXX -> not rewrited
+#include "YPython.h"
+#include "YPythonNamespace.h"
+using std::string;
+
+
+Y2PythonComponent::Y2PythonComponent()
+{
+    // Actual creation of a Python interpreter is postponed until one of the
+    // YPython static methods is used. They handle that.
+
+    y2milestone( "Creating Y2PythonComponent" );
+}
+
+
+Y2PythonComponent::~Y2PythonComponent()
+{
+    YPython::destroy();
+}
+
+
+void Y2PythonComponent::result( const YCPValue & )
+{
+}
+
+
+Y2Namespace *Y2PythonComponent::import (const char* name)
+{
+    // TODO where to look for it
+    // must be the same in Y2CCPython and Y2PythonComponent
+
+    string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
+    if (module.empty ())
+    {
+	y2internal ("Couldn't find %s after Y2CCPython pointed to us", name);
+	return NULL;
+    }
+
+    //import module and add his dictionary to YPython::_pMainDicts
+    YPython::loadModule (module);
+
+    // introspect, create data structures for the interpreter
+    Y2Namespace *ns = new YPythonNamespace (name);
+
+    return ns;
+}

--- a/src/Y2PythonComponent.cc
+++ b/src/Y2PythonComponent.cc
@@ -62,7 +62,7 @@ Y2Namespace *Y2PythonComponent::import (const char* name)
     }
 
     //import module and add his dictionary to YPython::_pMainDicts
-    YPython::loadModule (module);
+    YPython::yPython().loadModule (module);
 
     // introspect, create data structures for the interpreter
     Y2Namespace *ns = new YPythonNamespace (name);

--- a/src/Y2PythonComponent.cc
+++ b/src/Y2PythonComponent.cc
@@ -55,10 +55,9 @@ Y2Namespace *Y2PythonComponent::import (const char* name)
     // must be the same in Y2CCPython and Y2PythonComponent
 
     string module = YCPPathSearch::find (YCPPathSearch::Module, string (name) + ".py");
-    if (module.empty ())
-    {
-	y2internal ("Couldn't find %s after Y2CCPython pointed to us", name);
-	return NULL;
+    if (module.empty ()) {
+        y2internal ("Couldn't find %s after Y2CCPython pointed to us", name);
+        return NULL;
     }
 
     //import module and add his dictionary to YPython::_pMainDicts

--- a/src/Y2PythonComponent.h
+++ b/src/Y2PythonComponent.h
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      Y2PythonComponent.h
+
+
+
+/-*/
+
+
+#ifndef Y2PythonComponent_h
+#define Y2PythonComponent_h
+
+#include <Python.h>
+#include "Y2.h"
+
+
+/**
+ * @short YaST2 Component: Python bindings
+ */
+class Y2PythonComponent : public Y2Component
+{
+public:
+    /**
+     * Constructor.
+     */
+    Y2PythonComponent();
+
+    /**
+     * Destructor.
+     */
+    ~Y2PythonComponent();
+
+    /**
+     * The name of this component.
+     */
+    string name() const { return "python"; }
+
+    /**
+     * Is called by the generic frontend when the session is finished.
+     */
+    void result( const YCPValue & result );
+
+    /**
+     * Implements the Python:: functions.
+     **/
+// not yet, prototype the transparent bindings first
+//    YCPValue evaluate( const YCPValue & val );
+
+    /**
+     * Try to import a given namespace. This method is used
+     * for transparent handling of namespaces (YCP modules)
+     * through whole YaST.
+     * @param name_space the name of the required namespace
+     * @return on errors, NULL should be returned. The
+     * error reporting must be done by the component itself
+     * (typically using y2log). On success, the method
+     * should return a proper instance of the imported namespace
+     * ready to be used. The returned instance is still owned
+     * by the component, any other part of YaST will try to
+     * free it. Thus, it's possible to share the instance.
+     */
+    Y2Namespace *import (const char* name);
+};
+
+#endif	// Y2PythonComponent_h

--- a/src/Y2PythonComponent.h
+++ b/src/Y2PythonComponent.h
@@ -51,12 +51,6 @@ public:
     void result( const YCPValue & result );
 
     /**
-     * Implements the Python:: functions.
-     **/
-// not yet, prototype the transparent bindings first
-//    YCPValue evaluate( const YCPValue & val );
-
-    /**
      * Try to import a given namespace. This method is used
      * for transparent handling of namespaces (YCP modules)
      * through whole YaST.

--- a/src/Y2PythonComponent.h
+++ b/src/Y2PythonComponent.h
@@ -43,7 +43,10 @@ public:
     /**
      * The name of this component.
      */
-    string name() const { return "python"; }
+    string name() const
+    {
+        return "python";
+    }
 
     /**
      * Is called by the generic frontend when the session is finished.

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -30,9 +30,10 @@ YCPDeclarations *YCPDeclarations::instance()
 bool YCPDeclarations::_isInCache(PyFunctionObject *func) const
 {
     int len = _cache.size();
-    for (int i=0; i < len; i++){
-        if (_cache[i]->function == func)
+    for (int i=0; i < len; i++) {
+        if (_cache[i]->function == func) {
             return true;
+        }
     }
 
     return false;
@@ -47,27 +48,28 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
     cache_function_t *function;
     Py_ssize_t tuple_size;
 
-    if (!_init())
+    if (!_init()) {
         return;
+    }
 
-    if (_isInCache(func)){
+    if (_isInCache(func)) {
         y2debug("function (%ld, %s) is already in cache.", (long)func, PyStr_AsString(func->func_name));
         return;
     }
 
     item = _getItemFromFunctionMap((PyObject *)func);
-    if (item == NULL || !PyDict_Check(item)){
+    if (item == NULL || !PyDict_Check(item)) {
         y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyStr_AsString(func->func_name));
         return;
     }
 
     return_type = PyDict_GetItemString(item, "return_type");
-    if (return_type == NULL || !PyUnicode_Check(return_type)){
+    if (return_type == NULL || !PyUnicode_Check(return_type)) {
         y2debug("Invalid return type of function (%ld, %s)", (long)func, PyStr_AsString(func->func_name));
         return;
     }
     params = PyDict_GetItemString(item, "parameters");
-    if (params == NULL || !PyTuple_Check(params)){
+    if (params == NULL || !PyTuple_Check(params)) {
         y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyStr_AsString(func->func_name));
         return;
     }
@@ -83,7 +85,7 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
 
     //parameters:
     tuple_size = PyTuple_Size(params);
-    for (Py_ssize_t i=0; i < tuple_size; i++){
+    for (Py_ssize_t i=0; i < tuple_size; i++) {
         tmp = PyTuple_GetItem(params, i);
         function->parameters.push_back(_interpretType(PyStr_AsString(tmp)));
     }
@@ -99,15 +101,15 @@ const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyF
     int len = _cache.size();
 
     y2debug("Searching for function (%ld, %s)...", (long)func, PyStr_AsString(func->func_name));
-    for (int i=0; i < len; i++){
-        if (_cache[i]->function == func){
+    for (int i=0; i < len; i++) {
+        if (_cache[i]->function == func) {
             y2debug("    ==> Function found on position %d", i);
             ret = _cache[i];
             break;
         }
     }
 
-    if (ret == NULL){
+    if (ret == NULL) {
         y2debug("    ==> Function not found");
     }
 
@@ -117,16 +119,18 @@ const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyF
 
 PyObject *YCPDeclarations::_getItemFromFunctionMap(PyObject *key)
 {
-    if (!_init())
+    if (!_init()) {
         return NULL;
+    }
 
-    if (_py_self == NULL)
+    if (_py_self == NULL) {
         return NULL;
+    }
 
     PyObject *dict = PyModule_GetDict(_py_self);
     PyObject *func_map = PyDict_GetItemString(dict, "_function_map");
 
-    if (!PyDict_Check(func_map)){
+    if (!PyDict_Check(func_map)) {
         y2error("Map _function_map not found in python module YCPDeclarations");
         return NULL;
     }
@@ -139,26 +143,36 @@ constTypePtr YCPDeclarations::_interpretType(const char *c_type) const
 {
     string type(c_type);
 
-    if (type == "void")
+    if (type == "void") {
         return Type::Void;
-    if (type == "boolean")
+    }
+    if (type == "boolean") {
         return Type::Boolean;
-    if (type == "float")
+    }
+    if (type == "float") {
         return Type::Float;
-    if (type == "integer")
+    }
+    if (type == "integer") {
         return Type::Integer;
-    if (type == "path")
+    }
+    if (type == "path") {
         return Type::Path;
-    if (type == "string")
+    }
+    if (type == "string") {
         return Type::String;
-    if (type == "symbol")
+    }
+    if (type == "symbol") {
         return Type::Symbol;
-    if (type == "term")
+    }
+    if (type == "term") {
         return Type::Term;
-    if (type == "map")
+    }
+    if (type == "map") {
         return Type::Map;
-    if (type == "list")
+    }
+    if (type == "list") {
         return Type::List;
+    }
 
     // default:
     return Type::Any;
@@ -167,16 +181,17 @@ constTypePtr YCPDeclarations::_interpretType(const char *c_type) const
 
 bool YCPDeclarations::_init()
 {
-    if (_py_self != NULL)
+    if (_py_self != NULL) {
         return true;
+    }
 
-    if (!Py_IsInitialized()){
+    if (!Py_IsInitialized()) {
         y2error("Python interpret is not initialized!");
         return false;
     }
 
     _py_self = PyImport_ImportModule("YCPDeclarations");
-    if (_py_self == NULL){
+    if (_py_self == NULL) {
         y2error("Failed to import YCPDeclarations module!");
         return false;
     }
@@ -199,7 +214,7 @@ YCPDeclarations::YCPDeclarations() : _py_self(NULL)
 YCPDeclarations::~YCPDeclarations()
 {
     int cache_len = _cache.size();
-    for (int i=0; i < cache_len; i++){
+    for (int i=0; i < cache_len; i++) {
         delete _cache[i];
     }
 
@@ -212,8 +227,9 @@ int YCPDeclarations::numParams(PyFunctionObject *func)
     _cacheFunction(func);
 
     const cache_function_t *function = _getCachedFunction(func);
-    if (function == NULL)
+    if (function == NULL) {
         return -1;
+    }
 
     y2debug("Number of parameters of function (%ld, %s) is %d",
             (long)func, PyStr_AsString(func->func_name), (int)function->parameters.size());
@@ -232,7 +248,7 @@ vector<constTypePtr> YCPDeclarations::params(PyFunctionObject *func)
     _cacheFunction(func);
 
     const cache_function_t *function = _getCachedFunction(func);
-    if (function == NULL){
+    if (function == NULL) {
         return vector<constTypePtr>();
     }
 
@@ -244,7 +260,7 @@ constTypePtr YCPDeclarations::returnType(PyFunctionObject *func)
     _cacheFunction(func);
 
     const cache_function_t *function = _getCachedFunction(func);
-    if (function == NULL){
+    if (function == NULL) {
         return _interpretType("any");
     }
 

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -1,0 +1,258 @@
+#include "YCPDeclarations.h"
+#include <iostream>
+
+#define y2log_component "YCPDeclarations"
+#include <ycp/y2log.h>
+
+using std::string;
+using std::vector;
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+
+/********** STATIC MEMBERS **********/
+YCPDeclarations YCPDeclarations::_instance;
+YCPDeclarations *YCPDeclarations::instance()
+{
+    return &_instance;
+}
+
+/********** STATIC MEMBERS END **********/
+
+
+
+
+/********** PRIVATE **********/
+bool YCPDeclarations::_isInCache(PyFunctionObject *func) const
+{
+    int len = _cache.size();
+    for (int i=0; i < len; i++){
+        if (_cache[i]->function == func)
+            return true;
+    }
+
+    return false;
+}
+
+void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
+{
+    PyObject *item;
+    PyObject *params;
+    PyObject *return_type;
+    PyObject *tmp;
+    cache_function_t *function;
+    Py_ssize_t tuple_size;
+
+    if (!_init())
+        return;
+
+    if (_isInCache(func)){
+        y2debug("function (%ld, %s) is already in cache.", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    item = _getItemFromFunctionMap((PyObject *)func);
+    if (item == NULL || !PyDict_Check(item)){
+        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    return_type = PyDict_GetItemString(item, "return_type");
+    if (return_type == NULL || !PyString_Check(return_type)){
+        y2debug("Invalid return type of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+    params = PyDict_GetItemString(item, "parameters");
+    if (params == NULL || !PyTuple_Check(params)){
+        y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+        return;
+    }
+
+    //allocate memory
+    function = new cache_function_t;
+
+    //function
+    function->function = func;
+
+    //return type:
+    function->return_type = _interpretType(PyString_AsString(return_type));
+
+    //parameters:
+    tuple_size = PyTuple_Size(params);
+    for (Py_ssize_t i=0; i < tuple_size; i++){
+        tmp = PyTuple_GetItem(params, i);
+        function->parameters.push_back(_interpretType(PyString_AsString(tmp)));
+    }
+
+    //add new function item
+    _cache.push_back(function);
+    y2debug("function (%ld, %s) cached", (long)func, PyString_AsString(func->func_name));
+}
+
+const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyFunctionObject *func) const
+{
+    cache_function_t *ret = NULL;
+    int len = _cache.size();
+
+    y2debug("Searching for function (%ld, %s)...", (long)func, PyString_AsString(func->func_name));
+    for (int i=0; i < len; i++){
+        if (_cache[i]->function == func){
+            y2debug("    ==> Function found on position %d", i);
+            ret = _cache[i];
+            break;
+        }
+    }
+
+    if (ret == NULL){
+        y2debug("    ==> Function not found");
+    }
+
+    return ret;
+}
+
+
+PyObject *YCPDeclarations::_getItemFromFunctionMap(PyObject *key)
+{
+    if (!_init())
+        return NULL;
+
+    if (_py_self == NULL)
+        return NULL;
+
+    PyObject *dict = PyModule_GetDict(_py_self);
+    PyObject *func_map = PyDict_GetItemString(dict, "_function_map");
+
+    if (!PyDict_Check(func_map)){
+        y2error("Map _function_map not found in python module YCPDeclarations");
+        return NULL;
+    }
+
+    return PyDict_GetItem(func_map, key);
+}
+
+
+constTypePtr YCPDeclarations::_interpretType(const char *c_type) const
+{
+    string type(c_type);
+
+    if (type == "void")
+        return Type::Void;
+    if (type == "boolean")
+        return Type::Boolean;
+    if (type == "float")
+        return Type::Float;
+    if (type == "integer")
+        return Type::Integer;
+    if (type == "path")
+        return Type::Path;
+    if (type == "string")
+        return Type::String;
+    if (type == "symbol")
+        return Type::Symbol;
+    if (type == "term")
+        return Type::Term;
+    if (type == "map")
+        return Type::Map;
+    if (type == "list")
+        return Type::List;
+
+    // default:
+    return Type::Any;
+}
+
+
+bool YCPDeclarations::_init()
+{
+    if (_py_self != NULL)
+        return true;
+
+    if (!Py_IsInitialized()){
+        y2error("Python interpret is not initialized!");
+        return false;
+    }
+
+    _py_self = PyImport_ImportModule("YCPDeclarations");
+    if (_py_self == NULL){
+        y2error("Failed to import YCPDeclarations module!");
+        return false;
+    }
+
+    y2milestone("YCPDeclarations successfuly initialized!");
+    return true;
+}
+/********** PRIVATE END **********/
+
+
+
+
+/********** PUBLIC **********/
+
+YCPDeclarations::YCPDeclarations() : _py_self(NULL)
+{
+    y2debug("Constructor called");
+}
+
+YCPDeclarations::~YCPDeclarations()
+{
+    int cache_len = _cache.size();
+    for (int i=0; i < cache_len; i++){
+        delete _cache[i];
+    }
+
+    if (_py_self != NULL)
+        Py_DECREF(_py_self);
+
+    y2debug("Destructor called");
+}
+
+
+int YCPDeclarations::numParams(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL)
+        return -1;
+
+    y2debug("Number of parameters of function (%ld, %s) is %d",
+            (long)func, PyString_AsString(func->func_name), (int)function->parameters.size());
+    return function->parameters.size();
+}
+
+bool YCPDeclarations::exists(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    return _isInCache(func);
+}
+
+vector<constTypePtr> YCPDeclarations::params(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL){
+        return vector<constTypePtr>();
+    }
+
+    return function->parameters;
+}
+
+constTypePtr YCPDeclarations::returnType(PyFunctionObject *func)
+{
+    _cacheFunction(func);
+
+    const cache_function_t *function = _getCachedFunction(func);
+    if (function == NULL){
+        return _interpretType("any");
+    }
+
+    return function->return_type;
+}
+
+bool YCPDeclarations::init()
+{
+    return _init();
+}
+/********** PUBLIC END **********/

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -6,6 +6,9 @@
 
 using std::string;
 using std::vector;
+
+#include "compat.h"
+
 #define DBG(str) \
     std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
     std::cerr.flush()

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -51,24 +51,41 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
         return;
 
     if (_isInCache(func)){
+#if PY_MAJOR_VERSION >= 3
+        y2debug("function (%ld, %s) is already in cache.", (long)func, _PyUnicode_AsString(func->func_name));
+#else
         y2debug("function (%ld, %s) is already in cache.", (long)func, PyString_AsString(func->func_name));
+#endif
         return;
     }
 
     item = _getItemFromFunctionMap((PyObject *)func);
     if (item == NULL || !PyDict_Check(item)){
+#if PY_MAJOR_VERSION >= 3
+        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, _PyUnicode_AsString(func->func_name));
+#else
         y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyString_AsString(func->func_name));
+#endif
         return;
     }
 
     return_type = PyDict_GetItemString(item, "return_type");
+#if PY_MAJOR_VERSION >= 3
+    if (return_type == NULL || !PyUnicode_Check(return_type)){
+        y2debug("Invalid return type of function (%ld, %s)", (long)func, _PyUnicode_AsString(func->func_name));
+#else
     if (return_type == NULL || !PyString_Check(return_type)){
         y2debug("Invalid return type of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+#endif
         return;
     }
     params = PyDict_GetItemString(item, "parameters");
     if (params == NULL || !PyTuple_Check(params)){
+#if PY_MAJOR_VERSION >= 3
+        y2debug("Invalid parameters of function (%ld, %s)", (long)func, _PyUnicode_AsString(func->func_name));
+#else
         y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
+#endif
         return;
     }
 
@@ -79,18 +96,30 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
     function->function = func;
 
     //return type:
+#if PY_MAJOR_VERSION >= 3
+    function->return_type = _interpretType(_PyUnicode_AsString(return_type));
+#else
     function->return_type = _interpretType(PyString_AsString(return_type));
+#endif
 
     //parameters:
     tuple_size = PyTuple_Size(params);
     for (Py_ssize_t i=0; i < tuple_size; i++){
         tmp = PyTuple_GetItem(params, i);
+#if PY_MAJOR_VERSION >= 3
+        function->parameters.push_back(_interpretType(_PyUnicode_AsString(tmp)));
+#else
         function->parameters.push_back(_interpretType(PyString_AsString(tmp)));
+#endif
     }
 
     //add new function item
     _cache.push_back(function);
+#if PY_MAJOR_VERSION >= 3
+    y2debug("function (%ld, %s) cached", (long)func, _PyUnicode_AsString(func->func_name));
+#else
     y2debug("function (%ld, %s) cached", (long)func, PyString_AsString(func->func_name));
+#endif
 }
 
 const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyFunctionObject *func) const
@@ -98,7 +127,11 @@ const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyF
     cache_function_t *ret = NULL;
     int len = _cache.size();
 
+#if PY_MAJOR_VERSION >= 3
+    y2debug("Searching for function (%ld, %s)...", (long)func, _PyUnicode_AsString(func->func_name));
+#else
     y2debug("Searching for function (%ld, %s)...", (long)func, PyString_AsString(func->func_name));
+#endif
     for (int i=0; i < len; i++){
         if (_cache[i]->function == func){
             y2debug("    ==> Function found on position %d", i);
@@ -203,8 +236,10 @@ YCPDeclarations::~YCPDeclarations()
         delete _cache[i];
     }
 
+#if PY_MAJOR_VERSION < 3
     if (_py_self != NULL)
         Py_DECREF(_py_self);
+#endif
 
     y2debug("Destructor called");
 }
@@ -219,7 +254,11 @@ int YCPDeclarations::numParams(PyFunctionObject *func)
         return -1;
 
     y2debug("Number of parameters of function (%ld, %s) is %d",
+#if PY_MAJOR_VERSION >= 3
+            (long)func, _PyUnicode_AsString(func->func_name), (int)function->parameters.size());
+#else
             (long)func, PyString_AsString(func->func_name), (int)function->parameters.size());
+#endif
     return function->parameters.size();
 }
 

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -51,41 +51,24 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
         return;
 
     if (_isInCache(func)){
-#if PY_MAJOR_VERSION >= 3
-        y2debug("function (%ld, %s) is already in cache.", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-        y2debug("function (%ld, %s) is already in cache.", (long)func, PyString_AsString(func->func_name));
-#endif
+        y2debug("function (%ld, %s) is already in cache.", (long)func, PyStr_AsString(func->func_name));
         return;
     }
 
     item = _getItemFromFunctionMap((PyObject *)func);
     if (item == NULL || !PyDict_Check(item)){
-#if PY_MAJOR_VERSION >= 3
-        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyString_AsString(func->func_name));
-#endif
+        y2debug("function (%ld, %s) is not declared using YCPDeclare", (long)func, PyStr_AsString(func->func_name));
         return;
     }
 
     return_type = PyDict_GetItemString(item, "return_type");
-#if PY_MAJOR_VERSION >= 3
     if (return_type == NULL || !PyUnicode_Check(return_type)){
-        y2debug("Invalid return type of function (%ld, %s)", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-    if (return_type == NULL || !PyString_Check(return_type)){
-        y2debug("Invalid return type of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
-#endif
+        y2debug("Invalid return type of function (%ld, %s)", (long)func, PyStr_AsString(func->func_name));
         return;
     }
     params = PyDict_GetItemString(item, "parameters");
     if (params == NULL || !PyTuple_Check(params)){
-#if PY_MAJOR_VERSION >= 3
-        y2debug("Invalid parameters of function (%ld, %s)", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-        y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyString_AsString(func->func_name));
-#endif
+        y2debug("Invalid parameters of function (%ld, %s)", (long)func, PyStr_AsString(func->func_name));
         return;
     }
 
@@ -96,30 +79,18 @@ void YCPDeclarations::_cacheFunction(PyFunctionObject *func)
     function->function = func;
 
     //return type:
-#if PY_MAJOR_VERSION >= 3
-    function->return_type = _interpretType(_PyUnicode_AsString(return_type));
-#else
-    function->return_type = _interpretType(PyString_AsString(return_type));
-#endif
+    function->return_type = _interpretType(PyStr_AsString(return_type));
 
     //parameters:
     tuple_size = PyTuple_Size(params);
     for (Py_ssize_t i=0; i < tuple_size; i++){
         tmp = PyTuple_GetItem(params, i);
-#if PY_MAJOR_VERSION >= 3
-        function->parameters.push_back(_interpretType(_PyUnicode_AsString(tmp)));
-#else
-        function->parameters.push_back(_interpretType(PyString_AsString(tmp)));
-#endif
+        function->parameters.push_back(_interpretType(PyStr_AsString(tmp)));
     }
 
     //add new function item
     _cache.push_back(function);
-#if PY_MAJOR_VERSION >= 3
-    y2debug("function (%ld, %s) cached", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-    y2debug("function (%ld, %s) cached", (long)func, PyString_AsString(func->func_name));
-#endif
+    y2debug("function (%ld, %s) cached", (long)func, PyStr_AsString(func->func_name));
 }
 
 const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyFunctionObject *func) const
@@ -127,11 +98,7 @@ const YCPDeclarations::cache_function_t *YCPDeclarations::_getCachedFunction(PyF
     cache_function_t *ret = NULL;
     int len = _cache.size();
 
-#if PY_MAJOR_VERSION >= 3
-    y2debug("Searching for function (%ld, %s)...", (long)func, _PyUnicode_AsString(func->func_name));
-#else
-    y2debug("Searching for function (%ld, %s)...", (long)func, PyString_AsString(func->func_name));
-#endif
+    y2debug("Searching for function (%ld, %s)...", (long)func, PyStr_AsString(func->func_name));
     for (int i=0; i < len; i++){
         if (_cache[i]->function == func){
             y2debug("    ==> Function found on position %d", i);
@@ -254,11 +221,7 @@ int YCPDeclarations::numParams(PyFunctionObject *func)
         return -1;
 
     y2debug("Number of parameters of function (%ld, %s) is %d",
-#if PY_MAJOR_VERSION >= 3
-            (long)func, _PyUnicode_AsString(func->func_name), (int)function->parameters.size());
-#else
-            (long)func, PyString_AsString(func->func_name), (int)function->parameters.size());
-#endif
+            (long)func, PyStr_AsString(func->func_name), (int)function->parameters.size());
     return function->parameters.size();
 }
 

--- a/src/YCPDeclarations.cc
+++ b/src/YCPDeclarations.cc
@@ -203,11 +203,6 @@ YCPDeclarations::~YCPDeclarations()
         delete _cache[i];
     }
 
-#if PY_MAJOR_VERSION < 3
-    if (_py_self != NULL)
-        Py_DECREF(_py_self);
-#endif
-
     y2debug("Destructor called");
 }
 

--- a/src/YCPDeclarations.h
+++ b/src/YCPDeclarations.h
@@ -120,7 +120,6 @@ class YCPDeclarations {
      */
     bool init();
 
-  //static
   private:
     /**
      * Here is stored pointer to YCPDeclare object.

--- a/src/YCPDeclarations.h
+++ b/src/YCPDeclarations.h
@@ -1,0 +1,137 @@
+#ifndef _YCPDECLARATIONS_H_
+#define _YCPDECLARATIONS_H_
+
+#include <Python.h>
+#include <ycp/Type.h>
+#include <vector>
+#include <string>
+#include <memory>
+
+/**
+ * This class stores information about declarations in python module which were
+ * done by YCPDeclarations module (YCPDeclaratios.py).
+ * This is class is singelton and static method instance() returns pointer to
+ * object.
+ *
+ * All methods which return any information about declared functions are
+ * called with argument pointer to PyFunctionObject (which identifies
+ * function unambiguously.
+ *
+ * Example of usage:
+ *
+ *      #include "YCPDeclarations.h"
+ *
+ *      PyObject *func = PyDict_GetItemString(dict, "function");
+ *      YCPDeclarations *decl = YCPDeclarations::instance();
+ *      int num_params = decl->numParams((PyFunctionObject *)func);
+ *      ...
+ *
+ */
+class YCPDeclarations {
+  private:
+    /**
+     * structure where can be stored cached function.
+     */
+    typedef struct{
+        PyFunctionObject *function;
+        constTypePtr return_type;
+        std::vector<constTypePtr> parameters;
+    } cache_function_t;
+
+
+    /**
+     * Pointer to Python module YCPDeclarations.
+     */
+    PyObject *_py_self;
+
+    /**
+     * List of cached functions.
+     */
+    std::vector<cache_function_t *> _cache;
+
+    /**
+     * Private construct.
+     * Call YCPDeclarations::instance() to get pointer to YCPDeclarations
+     * object.
+     */
+    YCPDeclarations();
+
+    /**
+     * Return item from function map which has key key.
+     * Return borrowed reference!
+     */
+    PyObject *_getItemFromFunctionMap(PyObject *key);
+
+    /**
+     * Interpret string as YCP type.
+     * This method must be synchronized with variable
+     * YCPDeclare._available_types from YCPDeclarations.py!!
+     */
+    constTypePtr _interpretType(const char *) const;
+
+    /**
+     * Return true, if func is in internal cache.
+     */
+    bool _isInCache(PyFunctionObject *func) const;
+
+    /**
+     * Cache function func if it is not already cached.
+     */
+    void _cacheFunction(PyFunctionObject *func);
+
+    /**
+     * Return pointer to struct which defines cached function.
+     * Memory pointed by returned pointer must _not_ be deleted! It points
+     * into internal list.
+     */
+    const cache_function_t *_getCachedFunction(PyFunctionObject *func) const;
+
+
+    /**
+     * Try to initialize _py_self. If _py_self is already initialized, nothing is done.
+     */
+    bool _init();
+
+  public:
+    ~YCPDeclarations();
+
+    /**
+     * Return number of parameters in declaration or -1 if function is not registered.
+     */
+    int numParams(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return true if function exists in YCPDeclarations module.
+     */
+    bool exists(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return list of YCP types corresponding with parameters fo function.
+     */
+    std::vector<constTypePtr> params(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Return return YCP type of function.
+     */
+    constTypePtr returnType(PyFunctionObject *pointer_to_function);
+
+    /**
+     * Initialize class.
+     */
+    bool init();
+
+  //static
+  private:
+    /**
+     * Here is stored pointer to YCPDeclare object.
+     */
+    static YCPDeclarations _instance;
+  public:
+    /**
+     * Return pointer to instance of YCPDeclare object.
+     */
+    static YCPDeclarations *instance();
+};
+
+#endif
+/* vim: set sw=4 ts=4 et ft=cpp cindent : */

--- a/src/YCPDeclarations.h
+++ b/src/YCPDeclarations.h
@@ -27,12 +27,13 @@
  *      ...
  *
  */
-class YCPDeclarations {
-  private:
+class YCPDeclarations
+{
+private:
     /**
      * structure where can be stored cached function.
      */
-    typedef struct{
+    typedef struct {
         PyFunctionObject *function;
         constTypePtr return_type;
         std::vector<constTypePtr> parameters;
@@ -92,7 +93,7 @@ class YCPDeclarations {
      */
     bool _init();
 
-  public:
+public:
     ~YCPDeclarations();
 
     /**
@@ -120,12 +121,12 @@ class YCPDeclarations {
      */
     bool init();
 
-  private:
+private:
     /**
      * Here is stored pointer to YCPDeclare object.
      */
     static YCPDeclarations _instance;
-  public:
+public:
     /**
      * Return pointer to instance of YCPDeclare object.
      */

--- a/src/YCPDeclarations.py
+++ b/src/YCPDeclarations.py
@@ -1,0 +1,105 @@
+"""
+ This module defines class YCPDeclare which can be used for defining
+ what return type and what types of arguments has function which will be
+ exported to YCP. For usage see YCPDeclare.__doc__.
+
+
+ Internal:
+ Important is variable _function_map which holds information about
+ functions. Contents of _function_map can be accessed from C:
+
+    PyObject *import = PyImport_ImportModule("YCPDeclarations");
+    PyObject *dict = PyModule_GetDict(import);
+    PyObject *func_map = PyDict_GetItemString(dict, "_function_map");
+    // now in func_map should be stored map describing functions declared by
+    // YCPDeclare
+
+ _function_map has form:
+    _function_map = {
+        pointer_to_function : {
+            "return_type" : "string",
+            "parameters" : [ list of strings representing types ]
+        }
+    }
+
+"""
+
+import inspect
+
+_function_map = {}
+def _addToFunctionMap(func_pointer, return_type, params_types):
+    global __function_map
+    _function_map[func_pointer] = {"return_type" : return_type,
+                                   "parameters" : params_types}
+
+class YCPDeclare:
+    """
+     Functor for definig return type and types of parameters
+     of function which will be exported into YCP. Best usage
+     is as decorator (see http://www.python.org/dev/peps/pep-0318).
+
+     Example of usage:
+         form YCPDeclarations import YCPDeclare
+
+         @YCPDeclare("string", "int", "int")
+         def function(i, ii):
+             \"\"\" Function which returns string a accept two
+                    integers as arguments. \"\"\"
+             return str(i+ii)
+    """
+
+    # tuple of types which can be used
+    # This list must be synchronized with
+    # YCPDeclarations::_interpretType function from YCPDeclarations.h!!
+    _available_types = (
+        "any",
+        "boolean",
+        "string",
+        "integer",
+        "term",
+        "symbol",
+        "path",
+        "float",
+        "void",
+        "map",
+        "list"
+    )
+
+    def __init__(self, return_type, *params_types):
+        self._return_type = ""
+        self._params = []
+
+        self._checkTypes((return_type,) + params_types)
+
+        self._return_type = return_type
+        self._params = params_types
+
+    def __call__(self, func):
+        """ Overridden operator() """
+
+        self._checkNumParams(func, len(self._params))
+
+        _addToFunctionMap(func, self._return_type, self._params)
+        return func
+
+
+    def _checkTypes(self, types):
+        """ Check if defined types are in _available_types """
+
+        _invalid_types = []
+        for type in types:
+            if type not in self._available_types:
+                _invalid_types.append(type)
+
+        if len(_invalid_types) != 0:
+            raise Exception("Unknnown types: " + str(_invalid_types))
+
+
+    def _checkNumParams(self, func, numTypes):
+        """ Check if number of parameters equals to number of defined types """
+
+        args = len(inspect.getargspec(func)[0])
+        if args != numTypes:
+            raise Exception("Number of declared types does not match number of arguments.")
+        
+

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -214,7 +214,13 @@ YPython::loadModule(string module)
            return YCPError("The module was not imported");
        }
 
-       int ret = PyDict_SetItem(YPython::_pMainDicts, pModuleName, PyModule_GetDict(pMain));
+       /* Something is broken somewhere, with py3 this line doesn't
+        * work when called from ruby (as a result of import "PythonModule"
+        * However when called from python (e.g. import_module("PythonModule")
+        * it works.
+        */
+       //int ret = PyDict_SetItem(YPython::_pMainDicts, pModuleName, PyModule_GetDict(pMain));
+       int ret = PyDict_SetItemString(YPython::_pMainDicts, module_name.c_str(), PyModule_GetDict(pMain));
        if (ret != 0)
           return YCPError("The module was not imported");
     } else {

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -99,13 +99,13 @@ YPython::~YPython(){}
  * return static _yPython
  **/
 
-YPython *
+YPython&
 YPython::yPython()
 {
     if ( ! _yPython )
 	_yPython = new YPython();
 
-    return _yPython;
+    return *_yPython;
 }
 
 /**
@@ -203,7 +203,7 @@ YPython::loadModule(string module)
     pModuleName = PyString_FromString(module_name.c_str());
     //check if dictionary contain "dictionary" for module
     if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
-       pMain = YPython::yPython()->importModule(module);
+       pMain = YPython::yPython().importModule(module);
        if (pMain == NULL){
            y2error("Can't import module %s", module_name.c_str());
 
@@ -253,7 +253,7 @@ YPython::callInner (string module, string function, bool method,
     YCPValue result = YCPNull ();
 
     // obtain correct dictionary for module
-    pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),module.c_str());
+    pMainDict = PyDict_GetItemString(YPython::yPython().pMainDicts(),module.c_str());
 
     // obtain function from dictionary
     if (PyDict_Contains(pMainDict,PyString_FromString(function.c_str())))

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -106,7 +106,7 @@ public:
 
 YPython * YPython::_yPython = 0;
 
-YPython::YPython():_pMainDicts(NULL){}
+YPython::YPython():_pMainDicts(PyDict_New()){}
 
 
 YPython::~YPython(){}
@@ -168,9 +168,6 @@ YPython::importModule(string modulePath){
        Py_Initialize();
     }
 
-    if (!YPython::_pMainDicts)
-       YPython::_pMainDicts = PyDict_New();
-
     // put module path in os.path for loading
     append_to_sys_path(module.path().c_str());
 
@@ -194,8 +191,6 @@ YPython::loadModule(string modulePath)
     PyObject* pMain = NULL;
     ModuleFilePath module(modulePath);
 
-    if (!YPython::_pMainDicts)
-       YPython::_pMainDicts = PyDict_New();
     //create python string for name of module
 
     pModuleName = PyString_FromString(module.name().c_str());
@@ -314,8 +309,6 @@ YPython::callInner (string module, string function, bool method,
 int YPython::findModuleFuncInDict(string module, string function) {
 
     PyObject * pModuleName = PyString_FromString(module.c_str());
-    if (_pMainDicts==NULL)
-       return -1;
     if (PyDict_Contains(_pMainDicts, pModuleName)) {
 
        PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
@@ -341,10 +334,6 @@ bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* fun
   
     PyObject * pModuleName = PyString_FromString(module.c_str());
     //check if dictionary contain "dictionary" for module
-
-    if (_pMainDicts==NULL) {
-       _pMainDicts = PyDict_New();
-    }
 
     if (PyDict_Contains(_pMainDicts, pModuleName)) {       
        PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -62,7 +62,8 @@
     std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
     std::cerr.flush()
 
-static bool append_to_sys_path(const string& path) {
+static bool append_to_sys_path(const string& path)
+{
     Py_ssize_t num_paths = 0;
     bool found = false;
     PyObject* pPaths = PySys_GetObject("path");
@@ -91,7 +92,8 @@ private:
     string file_path;
     string module_name;
 public:
-    ModuleFilePath(const string& fullModuleNamePath) {
+    ModuleFilePath(const string& fullModuleNamePath)
+    {
         size_t found = fullModuleNamePath.find_last_of("/");
         if (found != string::npos) {
             module_name = fullModuleNamePath.substr(found+1);
@@ -100,16 +102,22 @@ public:
         }
     }
 
-    const string& path() { return file_path; }
-    const string& name() { return module_name; }
+    const string& path()
+    {
+        return file_path;
+    }
+    const string& name()
+    {
+        return module_name;
+    }
 };
 
 YPython * YPython::_yPython = 0;
 
-YPython::YPython():_pMainDicts(PyDict_New()){}
+YPython::YPython():_pMainDicts(PyDict_New()) {}
 
 
-YPython::~YPython(){}
+YPython::~YPython() {}
 
 
 /**
@@ -119,8 +127,9 @@ YPython::~YPython(){}
 YPython&
 YPython::yPython()
 {
-    if ( ! _yPython )
-	_yPython = new YPython();
+    if ( ! _yPython ) {
+        _yPython = new YPython();
+    }
 
     return *_yPython;
 }
@@ -129,7 +138,7 @@ YPython::yPython()
  * return static _pMainDicts
  **/
 
-PyObject* 
+PyObject*
 YPython::pMainDicts()
 {
 
@@ -146,8 +155,9 @@ YPython::destroy()
 {
     y2milestone( "Shutting down embedded Python interpreter." );
 
-    if ( _yPython )
-	delete _yPython;
+    if ( _yPython ) {
+        delete _yPython;
+    }
 
     _yPython = 0;
     //Py_Finalize();
@@ -159,13 +169,14 @@ YPython::destroy()
  * import a module.
  **/
 PyObject *
-YPython::importModule(string modulePath){
+YPython::importModule(string modulePath)
+{
     PyObject* pModuleName = NULL;
     PyObject* pMain = NULL;
     ModuleFilePath module(modulePath);
     //initialize python
     if (!Py_IsInitialized()) {
-       Py_Initialize();
+        Py_Initialize();
     }
 
     // put module path in os.path for loading
@@ -175,7 +186,7 @@ YPython::importModule(string modulePath){
     pModuleName = PyString_FromString(module.name().c_str());
     //check if dictionary contain "dictionary" for module
     if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
-       pMain = PyImport_ImportModule(module.name().c_str());
+        pMain = PyImport_ImportModule(module.name().c_str());
     }
     return pMain;
 }
@@ -196,29 +207,30 @@ YPython::loadModule(string modulePath)
     pModuleName = PyString_FromString(module.name().c_str());
     //check if dictionary contain "dictionary" for module
     if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
-       pMain = YPython::yPython().importModule(modulePath);
-       if (pMain == NULL){
-           y2error("Can't import module %s", module.name().c_str());
+        pMain = YPython::yPython().importModule(modulePath);
+        if (pMain == NULL) {
+            y2error("Can't import module %s", module.name().c_str());
 
-           if (PyErr_Occurred() != NULL){
-              y2error("Python error: %s", PyErrorHandler().c_str());
-           }
+            if (PyErr_Occurred() != NULL) {
+                y2error("Python error: %s", PyErrorHandler().c_str());
+            }
 
-           return YCPError("The module was not imported");
-       }
+            return YCPError("The module was not imported");
+        }
 
-       int ret = PyDict_SetItemString(YPython::_pMainDicts, module.name().c_str(), PyModule_GetDict(pMain));
-       if (ret != 0)
-          return YCPError("The module was not imported");
+        int ret = PyDict_SetItemString(YPython::_pMainDicts, module.name().c_str(), PyModule_GetDict(pMain));
+        if (ret != 0) {
+            return YCPError("The module was not imported");
+        }
     } else {
 
-       y2error("The module is imported");
-       return YCPVoid();
+        y2error("The module is imported");
+        return YCPVoid();
     }
 
 
     return YCPVoid();
- 
+
 }
 
 /**
@@ -231,7 +243,7 @@ YPython::loadModule(string modulePath)
  **/
 YCPValue
 YPython::callInner (string module, string function, bool method,
-		  YCPList argList)
+                    YCPList argList)
 {
     PyObject* pMainDict;  // dictionary of module
     PyObject* pFunc;      // function from dictionary
@@ -243,15 +255,16 @@ YPython::callInner (string module, string function, bool method,
     pMainDict = PyDict_GetItemString(YPython::yPython().pMainDicts(),module.c_str());
 
     // obtain function from dictionary
-    if (PyDict_Contains(pMainDict,PyString_FromString(function.c_str())))
-       pFunc = PyDict_GetItemString(pMainDict, function.c_str());
-	else {
-	   y2error("Function %s is not found.", function.c_str());
-	   return result;
-	}
+    if (PyDict_Contains(pMainDict,PyString_FromString(function.c_str()))) {
+        pFunc = PyDict_GetItemString(pMainDict, function.c_str());
+    } else {
+        y2error("Function %s is not found.", function.c_str());
+        return result;
+    }
 
-    if (argList->size() !=0)
-       pArgs = PyTuple_New(argList->size()-1);
+    if (argList->size() !=0) {
+        pArgs = PyTuple_New(argList->size()-1);
+    }
 
     // Parsing argumments
     PyObject *pArg;
@@ -262,29 +275,29 @@ YPython::callInner (string module, string function, bool method,
     }
 
     // calling function from python
-    if (PyCallable_Check(pFunc))
-       pReturn = PyObject_Call(pFunc, pArgs, NULL);
-	else {
-	   y2error("Function %s is not callable.", function.c_str());
-	   return result;
-	}
+    if (PyCallable_Check(pFunc)) {
+        pReturn = PyObject_Call(pFunc, pArgs, NULL);
+    } else {
+        y2error("Function %s is not callable.", function.c_str());
+        return result;
+    }
     // delete arguments
     Py_CLEAR(pArgs);
 
     // convert python value to YCPValue
-    if (pReturn)
-        result = pyval_to_ycp(pReturn); // create YCP value
-    else{
+    if (pReturn) {
+        result = pyval_to_ycp(pReturn);    // create YCP value
+    } else {
         y2error("PyObject_CallObject(pFunc, pArgs) failed!");
-        if (PyErr_Occurred() != NULL){
-           y2error("Python error: %s", PyErrorHandler().c_str());
+        if (PyErr_Occurred() != NULL) {
+            y2error("Python error: %s", PyErrorHandler().c_str());
         }
     }
     // delete pReturn
     Py_CLEAR(pReturn);
 
     if (result.isNull ()) {
-       result = YCPVoid ();
+        result = YCPVoid ();
     }
 
     return result;
@@ -299,104 +312,109 @@ YPython::callInner (string module, string function, bool method,
  * return -1 if missing both (module and dinctionary)
 **/
 
-int YPython::findModuleFuncInDict(string module, string function) {
+int YPython::findModuleFuncInDict(string module, string function)
+{
 
     PyObject * pModuleName = PyString_FromString(module.c_str());
     if (PyDict_Contains(_pMainDicts, pModuleName)) {
 
-       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
-       if (PyDict_Contains(pMainDict, PyString_FromString(function.c_str())))
-          return 1;
-       else
-          return 0;
+        PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+        if (PyDict_Contains(pMainDict, PyString_FromString(function.c_str()))) {
+            return 1;
+        } else {
+            return 0;
+        }
 
     } else {
 
-       return -1;
+        return -1;
     }
 
 }
 
 /**
-  * Adding module name and function into 
-  * global dictionary 
+  * Adding module name and function into
+  * global dictionary
   * (necessary for calling python function via reference)
  **/
-bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* function) {
+bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* function)
+{
 
-  
+
     PyObject * pModuleName = PyString_FromString(module.c_str());
     //check if dictionary contain "dictionary" for module
 
-    if (PyDict_Contains(_pMainDicts, pModuleName)) {       
-       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+    if (PyDict_Contains(_pMainDicts, pModuleName)) {
+        PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
 
-       if (PyDict_Contains(pMainDict, PyString_FromString(fun_name.c_str()))) {
-	  return true;
+        if (PyDict_Contains(pMainDict, PyString_FromString(fun_name.c_str()))) {
+            return true;
 
-       } else {
-          if (PyDict_SetItemString(pMainDict, fun_name.c_str(), function) < 0) {
-             y2error("Adding new function %s to local dictionary", fun_name.c_str());
-             return false;
-          }
+        } else {
+            if (PyDict_SetItemString(pMainDict, fun_name.c_str(), function) < 0) {
+                y2error("Adding new function %s to local dictionary", fun_name.c_str());
+                return false;
+            }
 
-          if (PyDict_DelItemString(_pMainDicts, module.c_str()) <0) {
-             y2error("Deleting local dictionary %s from global dictionary failed", module.c_str());
-             return false;
-          }
+            if (PyDict_DelItemString(_pMainDicts, module.c_str()) <0) {
+                y2error("Deleting local dictionary %s from global dictionary failed", module.c_str());
+                return false;
+            }
 
-          if (PyDict_SetItemString(_pMainDicts, module.c_str(), pMainDict) <0) {
-             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
-             return false;
-          }
+            if (PyDict_SetItemString(_pMainDicts, module.c_str(), pMainDict) <0) {
+                y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+                return false;
+            }
 
-          return true;
-       }
+            return true;
+        }
     } else {
-       PyObject * newDict = PyDict_New();
+        PyObject * newDict = PyDict_New();
 
-       if (PyDict_SetItemString(newDict, fun_name.c_str(), function) < 0) {
-             y2error("Adding new function %s to local dictionary", fun_name.c_str());
-             return false;
-       }       
+        if (PyDict_SetItemString(newDict, fun_name.c_str(), function) < 0) {
+            y2error("Adding new function %s to local dictionary", fun_name.c_str());
+            return false;
+        }
 
-       if (PyDict_SetItemString(_pMainDicts, module.c_str(), newDict) <0) {
-             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
-             return false;
-       }
+        if (PyDict_SetItemString(_pMainDicts, module.c_str(), newDict) <0) {
+            y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+            return false;
+        }
 
-       return true;
+        return true;
     }
 }
 
-YCPValue YPython::findSymbolEntry(Y2Namespace *ns, string module, string function) {
+YCPValue YPython::findSymbolEntry(Y2Namespace *ns, string module, string function)
+{
 
-  if (ns) {
-     TableEntry *sym_te = ns->table ()->find (function.c_str());
+    if (ns) {
+        TableEntry *sym_te = ns->table ()->find (function.c_str());
 
-     if (sym_te == NULL) {
-	y2error ("No such symbol %s::%s", module.c_str(), function.c_str());
-	return YCPNull();
-     }
+        if (sym_te == NULL) {
+            y2error ("No such symbol %s::%s", module.c_str(), function.c_str());
+            return YCPNull();
+        }
 
-     SymbolEntryPtr sym_entry = sym_te->sentry();
-     return YCPReference(sym_entry);
+        SymbolEntryPtr sym_entry = sym_te->sentry();
+        return YCPReference(sym_entry);
 
-  } else {
-     y2error("Creating/Importing namespace for function %s failed", function.c_str());
-     return YCPNull();
-  }
+    } else {
+        y2error("Creating/Importing namespace for function %s failed", function.c_str());
+        return YCPNull();
+    }
 }
 
 /**
   * Convert Python Function to YCPCode.
-  * 
+  *
   * @param pointer to python function
   * @return YCPReference - Referecne
  **/
 
-YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
-    
+YCPValue YPython::fromPythonFunToReference (PyObject* pyFun)
+{
+
     PyObject *fun_code = PyFunction_GetCode(pyFun);
     string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
     string file_path = PyString_AsString(((PyCodeObject *) fun_code)->co_filename);
@@ -409,48 +427,48 @@ YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
     module_name.erase(module_name.size()-3);
 
     int find = findModuleFuncInDict(module_name, fun_name);
-  
+
     FunctionTypePtr sym_tp;
     Y2Namespace *ns;
 
     //namespace exist and includes function
     if (find == 1) {
-       ns = getNs (module_name.c_str());
+        ns = getNs (module_name.c_str());
 
-       return findSymbolEntry(ns, module_name, fun_name);
+        return findSymbolEntry(ns, module_name, fun_name);
 
-    //namespace exist but doesn't include function
+        //namespace exist but doesn't include function
     } else if (find ==0) {
-       addModuleAndFunction(module_name, fun_name, pyFun);
+        addModuleAndFunction(module_name, fun_name, pyFun);
 
-       ns = getNs (module_name.c_str());
+        ns = getNs (module_name.c_str());
 
-       if (ns) {
+        if (ns) {
 
-          SymbolEntry *result = ((YPythonNamespace *)ns)->AddFunction(pyFun);
-          if (result)
-             return YCPReference(result);
-          else {
-             y2error("Adding function %s to namespace %s failed", fun_name.c_str(), module_name.c_str());
-             return YCPNull();
-          }
-             
-       } else {
-          y2error("Importing namespace %s for function %s failed",
-                  module_name.c_str(), fun_name.c_str());
-          return YCPNull();
-       }
+            SymbolEntry *result = ((YPythonNamespace *)ns)->AddFunction(pyFun);
+            if (result) {
+                return YCPReference(result);
+            } else {
+                y2error("Adding function %s to namespace %s failed", fun_name.c_str(), module_name.c_str());
+                return YCPNull();
+            }
 
-    //namespace and function don't exist
+        } else {
+            y2error("Importing namespace %s for function %s failed",
+                    module_name.c_str(), fun_name.c_str());
+            return YCPNull();
+        }
+
+        //namespace and function don't exist
     } else {
 
-       addModuleAndFunction(module_name, fun_name, pyFun);
-       ns = new YPythonNamespace(module_name, pyFun);
+        addModuleAndFunction(module_name, fun_name, pyFun);
+        ns = new YPythonNamespace(module_name, pyFun);
 
-       //register new namespace
-       Import import(module_name, ns);
+        //register new namespace
+        Import import(module_name, ns);
 
-       return findSymbolEntry(ns, module_name, fun_name);
+        return findSymbolEntry(ns, module_name, fun_name);
 
     }
 
@@ -459,52 +477,56 @@ YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
 
 
 
-string YPython::PyErrorHandler() {
-   /* process Python-related errors */
-   /* call after Python API raises an exception */
- 
-   PyObject *errobj, *errdata, *errtraceback, *pystring;
+string YPython::PyErrorHandler()
+{
+    /* process Python-related errors */
+    /* call after Python API raises an exception */
 
-   string result = "error type: ";
-   /* get latest python exception info */
-   PyErr_Fetch(&errobj, &errdata, &errtraceback);
- 
-   pystring = NULL;
-   if (errobj != NULL &&
-      (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
-      (PyString_Check(pystring))
-      )
-      result += PyString_AsString(pystring);
-   else
-      result += "<unknown exception type>";
-   Py_XDECREF(pystring);
-   result +="; error value: ";
+    PyObject *errobj, *errdata, *errtraceback, *pystring;
 
-   pystring = NULL;
-   if (errdata != NULL &&
-      (pystring = PyObject_Str(errdata)) != NULL &&
-      (PyString_Check(pystring))
-      )
-      result += PyString_AsString(pystring);
-   else
-      result += "<unknown exception value>";
-   Py_XDECREF(pystring);
+    string result = "error type: ";
+    /* get latest python exception info */
+    PyErr_Fetch(&errobj, &errdata, &errtraceback);
 
-   result +="; error traceback: ";
+    pystring = NULL;
+    if (errobj != NULL &&
+            (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
+            (PyString_Check(pystring))
+       ) {
+        result += PyString_AsString(pystring);
+    } else {
+        result += "<unknown exception type>";
+    }
+    Py_XDECREF(pystring);
+    result +="; error value: ";
 
-   pystring = NULL;
-   if (errdata != NULL &&
-      (pystring = PyObject_Str(errtraceback)) != NULL &&
-      (PyString_Check(pystring))
-      )
-      result += PyString_AsString(pystring);
-   else
-      result += "<unknown exception traceback>";
-   Py_XDECREF(pystring);
-   Py_XDECREF(errobj);
-   Py_XDECREF(errdata);         /* caller owns all 3 */
-   Py_XDECREF(errtraceback);    /* already NULL'd out */
-   return result;
+    pystring = NULL;
+    if (errdata != NULL &&
+            (pystring = PyObject_Str(errdata)) != NULL &&
+            (PyString_Check(pystring))
+       ) {
+        result += PyString_AsString(pystring);
+    } else {
+        result += "<unknown exception value>";
+    }
+    Py_XDECREF(pystring);
+
+    result +="; error traceback: ";
+
+    pystring = NULL;
+    if (errdata != NULL &&
+            (pystring = PyObject_Str(errtraceback)) != NULL &&
+            (PyString_Check(pystring))
+       ) {
+        result += PyString_AsString(pystring);
+    } else {
+        result += "<unknown exception traceback>";
+    }
+    Py_XDECREF(pystring);
+    Py_XDECREF(errobj);
+    Py_XDECREF(errdata);         /* caller owns all 3 */
+    Py_XDECREF(errtraceback);    /* already NULL'd out */
+    return result;
 
 }
 

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -518,7 +518,29 @@ string YPython::PyErrorHandler()
             (pystring = PyObject_Str(errtraceback)) != NULL &&
             (PyString_Check(pystring))
        ) {
-        result += PyString_AsString(pystring);
+        PyObject *mod = PyImport_ImportModule("traceback");
+        if (mod) {
+            PyObject *traceStr = NULL;
+            PyObject *newline = PyUnicode_FromString("\n");
+            PyObject * meth_result =
+                PyObject_CallMethod(mod,
+                                    "format_exception",
+                                    "(OOO)",
+                                    errobj,
+                                    errdata,
+                                    errtraceback);
+            if (meth_result) {
+                traceStr = PyUnicode_Join(newline, meth_result);
+            }
+            if (traceStr) {
+                result += PyString_AsString(traceStr);
+            }
+            Py_XDECREF(meth_result);
+            Py_XDECREF(traceStr);
+            Py_XDECREF(newline);
+        } else {
+            result += PyString_AsString(pystring);
+        }
     } else {
         result += "<unknown exception traceback>";
     }

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -87,9 +87,7 @@ static bool append_to_sys_path(string& path) {
 
 YPython * YPython::_yPython = 0;
 
-PyObject * YPython::_pMainDicts = NULL;
-
-YPython::YPython(){}
+YPython::YPython():_pMainDicts(NULL){}
 
 
 YPython::~YPython(){}

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -53,6 +53,9 @@
 #include "yast.h"
 
 #include <iostream>
+
+#include "compat.h"
+
 #define DBG(str) \
     std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
     std::cerr.flush()

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -144,23 +144,16 @@ YPython::loadModule(string module)
           YPython::_pMainDicts = PyDict_New();
     }
 
+    PyObject* pPaths = PySys_GetObject("path");
+    PyList_Append(pPaths, PyString_FromString(path.c_str()));
     if (!YPython::_pMainDicts)
        YPython::_pMainDicts = PyDict_New();
     //create python string for name of module 
     pModuleName = PyString_FromString(module_name.c_str());
     //check if dictionary contain "dictionary" for module
     if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
-        pMain = PyModule_New(module_name.c_str());
-        PyModule_AddStringConstant(pMain, "__file__", module.c_str());
-        PyObject *localDict = PyModule_GetDict(pMain);
-        PyObject *builtins = PyEval_GetBuiltins();
-        PyDict_SetItemString(localDict, "__builtins__", builtins);
-
-        ifstream f(module.c_str());
-        string source((istreambuf_iterator<char>(f)), istreambuf_iterator<char>());
-
-        PyObject *pret = PyRun_String(source.c_str(), Py_file_input, localDict, localDict);
-        if (pret == NULL){
+       pMain = PyImport_ImportModule(module_name.c_str());
+       if (pMain == NULL){
            y2error("Can't import module %s", module_name.c_str());
 
            if (PyErr_Occurred() != NULL){

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -207,12 +207,6 @@ YPython::loadModule(string modulePath)
            return YCPError("The module was not imported");
        }
 
-       /* Something is broken somewhere, with py3 this line doesn't
-        * work when called from ruby (as a result of import "PythonModule"
-        * However when called from python (e.g. import_module("PythonModule")
-        * it works.
-        */
-       //int ret = PyDict_SetItem(YPython::_pMainDicts, pModuleName, PyModule_GetDict(pMain));
        int ret = PyDict_SetItemString(YPython::_pMainDicts, module.name().c_str(), PyModule_GetDict(pMain));
        if (ret != 0)
           return YCPError("The module was not imported");
@@ -284,7 +278,6 @@ YPython::callInner (string module, string function, bool method,
         y2error("PyObject_CallObject(pFunc, pArgs) failed!");
         if (PyErr_Occurred() != NULL){
            y2error("Python error: %s", PyErrorHandler().c_str());
-           //PyErr_Print();
         }
     }
     // delete pReturn
@@ -342,7 +335,6 @@ bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* fun
 	  return true;
 
        } else {
-          //PyObject * newDict = PyDict_New();
           if (PyDict_SetItemString(pMainDict, fun_name.c_str(), function) < 0) {
              y2error("Adding new function %s to local dictionary", fun_name.c_str());
              return false;
@@ -388,7 +380,6 @@ YCPValue YPython::findSymbolEntry(Y2Namespace *ns, string module, string functio
      }
 
      SymbolEntryPtr sym_entry = sym_te->sentry();
-     //cout << "entry" << sym_entry->toString()<< endl;
      return YCPReference(sym_entry);
 
   } else {
@@ -409,7 +400,6 @@ YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
     PyObject *fun_code = PyFunction_GetCode(pyFun);
     string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
     string file_path = PyString_AsString(((PyCodeObject *) fun_code)->co_filename);
-    //int no_args = ((PyCodeObject *) fun_code)->co_argcount;
 
     //found last "/" in path
     size_t found = file_path.find_last_of("/");
@@ -484,7 +474,6 @@ string YPython::PyErrorHandler() {
       (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
       (PyString_Check(pystring))
       )
-       //strcpy(save_error_type, PyString_AsString(pystring));
       result += PyString_AsString(pystring);
    else
       result += "<unknown exception type>";
@@ -496,10 +485,8 @@ string YPython::PyErrorHandler() {
       (pystring = PyObject_Str(errdata)) != NULL &&
       (PyString_Check(pystring))
       )
-       //strcpy(save_error_info, PyString_AsString(pystring));
       result += PyString_AsString(pystring);
    else
-       //strcpy(save_error_info, "<unknown exception data>");
       result += "<unknown exception value>";
    Py_XDECREF(pystring);
 
@@ -510,13 +497,10 @@ string YPython::PyErrorHandler() {
       (pystring = PyObject_Str(errtraceback)) != NULL &&
       (PyString_Check(pystring))
       )
-       //strcpy(save_error_info, PyString_AsString(pystring));
       result += PyString_AsString(pystring);
    else
-       //strcpy(save_error_info, "<unknown exception data>");
       result += "<unknown exception traceback>";
    Py_XDECREF(pystring);
-   //printf("%s\n%s\n", save_error_type, save_error_info);
    Py_XDECREF(errobj);
    Py_XDECREF(errdata);         /* caller owns all 3 */
    Py_XDECREF(errtraceback);    /* already NULL'd out */

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -1,0 +1,479 @@
+/*---------------------------------------------------------------------\
+|								       |
+|			__   __	  ____ _____ ____		       |
+|			\ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      YPython.cc
+
+
+
+/-*/
+
+#include <Python.h>
+#include <stdlib.h>
+#include <list>
+#include <iosfwd>
+#include <sstream>
+#include <iomanip>
+
+
+
+
+#define y2log_component "Y2Python"
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+
+#include <YPython.h>
+#include <ycp/YCPValue.h>
+#include <ycp/YCPBoolean.h>
+#include <ycp/YCPByteblock.h>
+#include <ycp/YCPFloat.h>
+#include <ycp/YCPInteger.h>
+#include <ycp/YCPList.h>
+#include <ycp/YCPMap.h>
+#include <ycp/YCPPath.h>
+#include <ycp/YCPString.h>
+#include <ycp/YCPSymbol.h>
+#include <ycp/YCPTerm.h>
+#include <ycp/YCPVoid.h>
+#include <ycp/YCPCode.h>
+#include <ycp/YCPExternal.h>
+#include <ycp/Point.h>
+
+#include "YPythonNamespace.h"
+#include "ytypes.h"
+#include "yast.h"
+
+#include <iostream>
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+YPython * YPython::_yPython = 0;
+
+PyObject * YPython::_pMainDicts = NULL;
+
+YPython::YPython(){}
+
+
+YPython::~YPython(){}
+
+
+/**
+ * return static _yPython
+ **/
+
+YPython *
+YPython::yPython()
+{
+    if ( ! _yPython )
+	_yPython = new YPython();
+
+    return _yPython;
+}
+
+/**
+ * return static _pMainDicts
+ **/
+
+PyObject* 
+YPython::pMainDicts()
+{
+
+    return _pMainDicts;
+}
+
+/**
+ * "static" destructor
+ **/
+
+
+YCPValue
+YPython::destroy()
+{
+    y2milestone( "Shutting down embedded Python interpreter." );
+
+    if ( _yPython )
+	delete _yPython;
+
+    _yPython = 0;
+    //Py_Finalize();
+    return YCPVoid();
+}
+
+
+
+/**
+ * Loads a module.
+ **/
+YCPValue
+YPython::loadModule(string module)
+{
+    string path;
+    string module_name;
+    PyObject* pModuleName;
+    size_t found;
+    PyObject* pMain;
+
+    //found last "/" in path
+    found = module.find_last_of("/");
+    //extract directory from path module
+    path = module.substr(0,found+1);
+    //extract module name from path
+    module_name = module.substr(found+1);
+    //delete last 3 chars from module name ".py"
+    module_name.erase(module_name.size()-3); //delete ".py"
+
+    //initialize python and set the path where are python modules
+    if (!Py_IsInitialized()) {
+       setenv("PYTHONPATH", path.c_str(), 1);       
+       Py_Initialize();
+       if (!YPython::_pMainDicts)
+          YPython::_pMainDicts = PyDict_New();
+    }
+
+    if (!YPython::_pMainDicts)
+       YPython::_pMainDicts = PyDict_New();
+    //create python string for name of module 
+    pModuleName = PyString_FromString(module_name.c_str());
+    //check if dictionary contain "dictionary" for module
+    if (PyDict_Contains(YPython::_pMainDicts, pModuleName) == 0) {
+       pMain = PyImport_ImportModule(module_name.c_str());
+       if (pMain == NULL){
+           y2error("Can't import module %s", module_name.c_str());
+
+           if (PyErr_Occurred() != NULL){
+              //string err = PyErrorHandler();
+              y2error("Python error: %s", PyErrorHandler().c_str());
+               //PyErr_Print();
+           }
+
+           return YCPError("The module was not imported");
+       }
+
+       int ret = PyDict_SetItem(YPython::_pMainDicts, pModuleName, PyModule_GetDict(pMain));
+       if (ret != 0)
+          return YCPError("The module was not imported");
+    } else {
+
+       //return YCPError("The module is imported");
+       y2error("The module is imported");
+       return YCPVoid();
+    }
+
+
+    return YCPVoid();
+ 
+}
+
+/**
+ * evaluate of function from python
+ * @param string name of module
+ * @param string name of function
+ * @param bool is it method? TODO !!
+ * @param YCPList argumnets from YCP to python function(0 - dummy)
+ * @return YCPValue return value from python's function
+ **/
+YCPValue
+YPython::callInner (string module, string function, bool method,
+		  YCPList argList)
+{
+    PyObject* pMainDict;  // dictionary of module
+    PyObject* pFunc;      // function from dictionary
+    PyObject* pArgs = NULL;      // tuple object of argument for function
+    PyObject* pReturn;    // return value from python
+    YCPValue result = YCPNull ();
+
+    // obtain correct dictionary for module
+    pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),module.c_str());
+
+    // obtain function from dictionary
+    if (PyDict_Contains(pMainDict,PyString_FromString(function.c_str())))
+       pFunc = PyDict_GetItemString(pMainDict, function.c_str());
+	else {
+	   y2error("Function %s is not found.", function.c_str());
+	   return result;
+	}
+
+    if (argList->size() !=0)
+       pArgs = PyTuple_New(argList->size()-1);
+
+    // Parsing argumments
+    PyObject *pArg;
+
+    for ( int i=1; i < argList->size(); i++ ) {
+        pArg = ycp_to_pyval(argList->value(i));
+        PyTuple_SetItem(pArgs,i-1, pArg);
+    }
+
+    // calling function from python
+    if (PyCallable_Check(pFunc))
+       pReturn = PyObject_Call(pFunc, pArgs, NULL);
+	else {
+	   y2error("Function %s is not callable.", function.c_str());
+	   return result;
+	}
+    // delete arguments
+    Py_CLEAR(pArgs);
+
+    // convert python value to YCPValue
+    if (pReturn)
+        result = pyval_to_ycp(pReturn); // create YCP value
+    else{
+        y2error("PyObject_CallObject(pFunc, pArgs) failed!");
+        if (PyErr_Occurred() != NULL){
+           y2error("Python error: %s", PyErrorHandler().c_str());
+           //PyErr_Print();
+        }
+    }
+    // delete pReturn
+    Py_CLEAR(pReturn);
+
+    if (result.isNull ()) {
+       result = YCPVoid ();
+    }
+
+    return result;
+}
+
+
+/**
+ * Find function in Global Dictionary
+ * confirm if function is from imported module or not
+ * return 1 if module is in dictionary and function too
+ * retrun 0 if module is in dictionary and function not
+ * return -1 if missing both (module and dinctionary)
+**/
+
+int YPython::findModuleFuncInDict(string module, string function) {
+
+    PyObject * pModuleName = PyString_FromString(module.c_str());
+    if (_pMainDicts==NULL)
+       return -1;
+    if (PyDict_Contains(_pMainDicts, pModuleName)) {
+
+       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+       if (PyDict_Contains(pMainDict, PyString_FromString(function.c_str())))
+          return 1;
+       else
+          return 0;
+
+    } else {
+
+       return -1;
+    }
+
+}
+
+/**
+  * Adding module name and function into 
+  * global dictionary 
+  * (necessary for calling python function via reference)
+ **/
+bool YPython::addModuleAndFunction(string module, string fun_name, PyObject* function) {
+
+  
+    PyObject * pModuleName = PyString_FromString(module.c_str());
+    //check if dictionary contain "dictionary" for module
+
+    if (_pMainDicts==NULL) {
+       _pMainDicts = PyDict_New();
+    }
+
+    if (PyDict_Contains(_pMainDicts, pModuleName)) {       
+       PyObject * pMainDict = PyDict_GetItemString(_pMainDicts, module.c_str());
+
+       if (PyDict_Contains(pMainDict, PyString_FromString(fun_name.c_str()))) {
+	  return true;
+
+       } else {
+          //PyObject * newDict = PyDict_New();
+          if (PyDict_SetItemString(pMainDict, fun_name.c_str(), function) < 0) {
+             y2error("Adding new function %s to local dictionary", fun_name.c_str());
+             return false;
+          }
+
+          if (PyDict_DelItemString(_pMainDicts, module.c_str()) <0) {
+             y2error("Deleting local dictionary %s from global dictionary failed", module.c_str());
+             return false;
+          }
+
+          if (PyDict_SetItemString(_pMainDicts, module.c_str(), pMainDict) <0) {
+             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+             return false;
+          }
+
+          return true;
+       }
+    } else {
+       PyObject * newDict = PyDict_New();
+
+       if (PyDict_SetItemString(newDict, fun_name.c_str(), function) < 0) {
+             y2error("Adding new function %s to local dictionary", fun_name.c_str());
+             return false;
+       }       
+
+       if (PyDict_SetItemString(_pMainDicts, module.c_str(), newDict) <0) {
+             y2error("Adding new local dictionary %s to global dictionary", module.c_str());
+             return false;
+       }
+
+       return true;
+    }
+}
+
+YCPValue YPython::findSymbolEntry(Y2Namespace *ns, string module, string function) {
+
+  if (ns) {
+     TableEntry *sym_te = ns->table ()->find (function.c_str());
+
+     if (sym_te == NULL) {
+	y2error ("No such symbol %s::%s", module.c_str(), function.c_str());
+	return YCPNull();
+     }
+
+     SymbolEntryPtr sym_entry = sym_te->sentry();
+     //cout << "entry" << sym_entry->toString()<< endl;
+     return YCPReference(sym_entry);
+
+  } else {
+     y2error("Creating/Importing namespace for function %s failed", function.c_str());
+     return YCPNull();
+  }
+}
+
+/**
+  * Convert Python Function to YCPCode.
+  * 
+  * @param pointer to python function
+  * @return YCPReference - Referecne
+ **/
+
+YCPValue YPython::fromPythonFunToReference (PyObject* pyFun) {
+    
+    PyObject *fun_code = PyFunction_GetCode(pyFun);
+    string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+    string file_path = PyString_AsString(((PyCodeObject *) fun_code)->co_filename);
+    //int no_args = ((PyCodeObject *) fun_code)->co_argcount;
+
+    //found last "/" in path
+    size_t found = file_path.find_last_of("/");
+    //extract module name from path
+    string module_name = file_path.substr(found+1);
+    //delete last 3 chars from module name ".py"
+    module_name.erase(module_name.size()-3);
+
+    int find = findModuleFuncInDict(module_name, fun_name);
+  
+    FunctionTypePtr sym_tp;
+    Y2Namespace *ns;
+
+    //namespace exist and includes function
+    if (find == 1) {
+       ns = getNs (module_name.c_str());
+
+       return findSymbolEntry(ns, module_name, fun_name);
+
+    //namespace exist but doesn't include function
+    } else if (find ==0) {
+       addModuleAndFunction(module_name, fun_name, pyFun);
+
+       ns = getNs (module_name.c_str());
+
+       if (ns) {
+
+          SymbolEntry *result = ((YPythonNamespace *)ns)->AddFunction(pyFun);
+          if (result)
+             return YCPReference(result);
+          else {
+             y2error("Adding function %s to namespace %s failed", fun_name.c_str(), module_name.c_str());
+             return YCPNull();
+          }
+             
+       } else {
+          y2error("Importing namespace %s for function %s failed",
+                  module_name.c_str(), fun_name.c_str());
+          return YCPNull();
+       }
+
+    //namespace and function don't exist
+    } else {
+
+       addModuleAndFunction(module_name, fun_name, pyFun);
+       ns = new YPythonNamespace(module_name, pyFun);
+
+       //register new namespace
+       Import import(module_name, ns);
+
+       return findSymbolEntry(ns, module_name, fun_name);
+
+    }
+
+    return YCPNull();
+}
+
+
+
+string YPython::PyErrorHandler() {
+   /* process Python-related errors */
+   /* call after Python API raises an exception */
+ 
+   PyObject *errobj, *errdata, *errtraceback, *pystring;
+
+   string result = "error type: ";
+   /* get latest python exception info */
+   PyErr_Fetch(&errobj, &errdata, &errtraceback);
+ 
+   pystring = NULL;
+   if (errobj != NULL &&
+      (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_type, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+      result += "<unknown exception type>";
+   Py_XDECREF(pystring);
+   result +="; error value: ";
+
+   pystring = NULL;
+   if (errdata != NULL &&
+      (pystring = PyObject_Str(errdata)) != NULL &&
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_info, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+       //strcpy(save_error_info, "<unknown exception data>");
+      result += "<unknown exception value>";
+   Py_XDECREF(pystring);
+
+   result +="; error traceback: ";
+
+   pystring = NULL;
+   if (errdata != NULL &&
+      (pystring = PyObject_Str(errtraceback)) != NULL &&
+      (PyString_Check(pystring))
+      )
+       //strcpy(save_error_info, PyString_AsString(pystring));
+      result += PyString_AsString(pystring);
+   else
+       //strcpy(save_error_info, "<unknown exception data>");
+      result += "<unknown exception traceback>";
+   Py_XDECREF(pystring);
+   //printf("%s\n%s\n", save_error_type, save_error_info);
+   Py_XDECREF(errobj);
+   Py_XDECREF(errdata);         /* caller owns all 3 */
+   Py_XDECREF(errtraceback);    /* already NULL'd out */
+   return result;
+
+}
+

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -34,7 +34,14 @@ class YPython
 public:
 
     /**
-     * Load a Python module - equivalent to "use" in Python.
+     *
+     * import a Python module
+     */
+
+     PyObject* importModule(string module);
+
+    /**
+     * Load a Python YAST module
      *
      * Returns a YCPError on failure, YCPVoid on success.
      **/

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -53,7 +53,7 @@ public:
      *
      * Returns 0 on error.
      **/
-    static YPython * yPython();
+    static YPython& yPython();
 
     /**
      * Access the static _pMainDicts

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -110,7 +110,7 @@ private:
      * 
      **/
 
-    static PyObject* _pMainDicts;
+    PyObject* _pMainDicts;
     /**
      * Find function in Global Dictionary
      * confirm if function is from imported module or not

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -78,18 +78,6 @@ public:
 			YCPList argList);
 
 
-    /**
-     * Transform Python type to YCP type and return new YCPValue built
-     * from python object.
-     */
-    YCPValue PythonTypeToYCPType(PyObject*);
-
-    /**
-     * Transform YCP type to Python type and return reference to new
-     * Python object.
-     */
-    PyObject *YCPTypeToPythonType(YCPValue);
-
    /**
      * Handler for python errors, info will be saved into  yast logs
      * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
@@ -128,48 +116,6 @@ private:
      **/
     bool addModuleAndFunction(string module, string fun_name, PyObject* function);
 
-
-    /**
-     * Convert a Python list to a YCPList.
-     **/
-    YCPList fromPythonListToYCPList (PyObject* pPythonList);
-
-    /**
-     * Convert a YCPList to a Python list.
-     **/
-    PyObject* fromYCPListToPythonList (YCPValue ycp_List);
-
-    /**
-     * Convert a Python Dictionary to a YCPMap.
-     **/
-    YCPMap fromPythonDictToYCPMap (PyObject* pPythonDict);
-
-
-    /**
-     * Convert a YCPMap to a Python Dictionary.
-     **/
-    PyObject* fromYCPMapToPythonDict (YCPValue ycp_Map);
-
-    /**
-     * Convert a Python Tuple to YCPList
-     **/
-    YCPList fromPythonTupleToYCPList (PyObject* pPythonTuple);
-
-    /**
-     * Convert a YCPList to a Python tuple.
-     **/
-    PyObject* fromYCPListToPythonTuple (YCPValue ycp_List);
-
-    /**
-     * Convert a Python Tuple to YCPList
-     **/
-    YCPTerm fromPythonTermToYCPTerm (PyObject* pPythonTerm);
-
-    /**
-     * Convert a YCPList to a Python tuple.
-     **/
-    PyObject* fromYCPTermToPythonTerm (YCPValue ycp_Term);
-
     /**
      * Function find in namespace function and return symbol entry
      **/
@@ -187,9 +133,6 @@ protected:
      * Destructor.
      **/
     ~YPython();
-
-    
-
 
 };
 

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -97,6 +97,11 @@ public:
      **/
     static string PyErrorHandler();
 
+    /**
+     * Prepare YCPReference for calling python function in YCP via reference
+     **/
+    YCPValue fromPythonFunToReference (PyObject* pyFun);
+
 private:
 
     /**
@@ -157,12 +162,6 @@ private:
      * Convert a YCPList to a Python tuple.
      **/
     PyObject* fromYCPTermToPythonTerm (YCPValue ycp_Term);
-
-    /**
-     * Prepare YCPReference for calling python function in YCP via reference
-     **/
-    YCPValue fromPythonFunToReference (PyObject* pyFun);
-
 
     /**
      * Function find in namespace function and return symbol entry

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -45,7 +45,7 @@ public:
      *
      * Returns a YCPError on failure, YCPVoid on success.
      **/
-    static YCPValue loadModule(string module);
+    YCPValue loadModule(string module);
 
     /**
      * Access the static (singleton) YPython object. Create it if it isn't
@@ -62,12 +62,6 @@ public:
 
     PyObject* pMainDicts();
 
-    /**
-     * static _pMainDicts includes dictionaries of all imported python modules
-     * 
-     **/
-
-    static PyObject* _pMainDicts;
 
     /**
      * Destroy the static (singleton) YPython object and unload the embedded Python
@@ -82,8 +76,6 @@ public:
      **/
     YCPValue callInner (string module, string function, bool method,
 			YCPList argList);
-    
-    static YPython * _yPython;
 
 
     /**
@@ -102,7 +94,7 @@ public:
      * Handler for python errors, info will be saved into  yast logs
      * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
      **/
-    static string PyErrorHandler();
+    string PyErrorHandler();
 
     /**
      * Prepare YCPReference for calling python function in YCP via reference
@@ -111,6 +103,14 @@ public:
 
 private:
 
+    
+    static YPython * _yPython;
+    /**
+     * static _pMainDicts includes dictionaries of all imported python modules
+     * 
+     **/
+
+    static PyObject* _pMainDicts;
     /**
      * Find function in Global Dictionary
      * confirm if function is from imported module or not

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -38,7 +38,7 @@ public:
      * import a Python module
      */
 
-     PyObject* importModule(string module);
+    PyObject* importModule(string module);
 
     /**
      * Load a Python YAST module
@@ -57,7 +57,7 @@ public:
 
     /**
      * Access the static _pMainDicts
-     * 
+     *
      **/
 
     PyObject* pMainDicts();
@@ -75,13 +75,13 @@ public:
      * Generic Python call.
      **/
     YCPValue callInner (string module, string function, bool method,
-			YCPList argList);
+                        YCPList argList);
 
 
-   /**
-     * Handler for python errors, info will be saved into  yast logs
-     * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
-     **/
+    /**
+      * Handler for python errors, info will be saved into  yast logs
+      * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
+      **/
     string PyErrorHandler();
 
     /**
@@ -91,11 +91,11 @@ public:
 
 private:
 
-    
+
     static YPython * _yPython;
     /**
      * static _pMainDicts includes dictionaries of all imported python modules
-     * 
+     *
      **/
 
     PyObject* _pMainDicts;
@@ -109,11 +109,11 @@ private:
 
     int findModuleFuncInDict(string module, string function);
 
-   /**
-     * Adding module name and function into 
-     * global dictionary 
-     * (necessary for calling python function via reference)
-     **/
+    /**
+      * Adding module name and function into
+      * global dictionary
+      * (necessary for calling python function via reference)
+      **/
     bool addModuleAndFunction(string module, string fun_name, PyObject* function);
 
     /**

--- a/src/YPython.h
+++ b/src/YPython.h
@@ -1,0 +1,191 @@
+/*-----------------------------------------------------------*- c++ -*-\
+|								       |
+|		       __   __	  ____ _____ ____		       |
+|		       \ \ / /_ _/ ___|_   _|___ \		       |
+|			\ V / _` \___ \ | |   __) |		       |
+|			 | | (_| |___) || |  / __/		       |
+|			 |_|\__,_|____/ |_| |_____|		       |
+|								       |
+|				core system			       |
+|						     (C) SuSE Linux AG |
+\----------------------------------------------------------------------/
+
+  File:	      YPython.h
+
+
+/-*/
+
+
+#ifndef YPython_h
+#define YPython_h
+
+#include <Python.h>
+
+#include <ycp/YCPList.h>
+#include <ycp/YCPValue.h>
+#include <ycp/Type.h>
+#include <ycp/YCPCode.h>
+#include <ycp/YCode.h>
+
+
+
+class YPython
+{
+public:
+
+    /**
+     * Load a Python module - equivalent to "use" in Python.
+     *
+     * Returns a YCPError on failure, YCPVoid on success.
+     **/
+    static YCPValue loadModule(string module);
+
+    /**
+     * Access the static (singleton) YPython object. Create it if it isn't
+     * created yet.
+     *
+     * Returns 0 on error.
+     **/
+    static YPython * yPython();
+
+    /**
+     * Access the static _pMainDicts
+     * 
+     **/
+
+    PyObject* pMainDicts();
+
+    /**
+     * static _pMainDicts includes dictionaries of all imported python modules
+     * 
+     **/
+
+    static PyObject* _pMainDicts;
+
+    /**
+     * Destroy the static (singleton) YPython object and unload the embedded Python
+     * interpreter.
+     *
+     * Returns YCPVoid().
+     **/
+    static YCPValue destroy();
+
+    /**
+     * Generic Python call.
+     **/
+    YCPValue callInner (string module, string function, bool method,
+			YCPList argList);
+    
+    static YPython * _yPython;
+
+
+    /**
+     * Transform Python type to YCP type and return new YCPValue built
+     * from python object.
+     */
+    YCPValue PythonTypeToYCPType(PyObject*);
+
+    /**
+     * Transform YCP type to Python type and return reference to new
+     * Python object.
+     */
+    PyObject *YCPTypeToPythonType(YCPValue);
+
+   /**
+     * Handler for python errors, info will be saved into  yast logs
+     * FUnction saves info from void PyErr_Fetch(PyObject **ptype, PyObject **pvalue, PyObject **ptraceback)
+     **/
+    static string PyErrorHandler();
+
+private:
+
+    /**
+     * Find function in Global Dictionary
+     * confirm if function is from imported module or not
+     * return 1 if module is in dictionary and function too
+     * retrun 0 if module is in dictionary and function not
+     * return -1 if missing both (module and dinctionary)
+     **/
+
+    int findModuleFuncInDict(string module, string function);
+
+   /**
+     * Adding module name and function into 
+     * global dictionary 
+     * (necessary for calling python function via reference)
+     **/
+    bool addModuleAndFunction(string module, string fun_name, PyObject* function);
+
+
+    /**
+     * Convert a Python list to a YCPList.
+     **/
+    YCPList fromPythonListToYCPList (PyObject* pPythonList);
+
+    /**
+     * Convert a YCPList to a Python list.
+     **/
+    PyObject* fromYCPListToPythonList (YCPValue ycp_List);
+
+    /**
+     * Convert a Python Dictionary to a YCPMap.
+     **/
+    YCPMap fromPythonDictToYCPMap (PyObject* pPythonDict);
+
+
+    /**
+     * Convert a YCPMap to a Python Dictionary.
+     **/
+    PyObject* fromYCPMapToPythonDict (YCPValue ycp_Map);
+
+    /**
+     * Convert a Python Tuple to YCPList
+     **/
+    YCPList fromPythonTupleToYCPList (PyObject* pPythonTuple);
+
+    /**
+     * Convert a YCPList to a Python tuple.
+     **/
+    PyObject* fromYCPListToPythonTuple (YCPValue ycp_List);
+
+    /**
+     * Convert a Python Tuple to YCPList
+     **/
+    YCPTerm fromPythonTermToYCPTerm (PyObject* pPythonTerm);
+
+    /**
+     * Convert a YCPList to a Python tuple.
+     **/
+    PyObject* fromYCPTermToPythonTerm (YCPValue ycp_Term);
+
+    /**
+     * Prepare YCPReference for calling python function in YCP via reference
+     **/
+    YCPValue fromPythonFunToReference (PyObject* pyFun);
+
+
+    /**
+     * Function find in namespace function and return symbol entry
+     **/
+    YCPValue findSymbolEntry(Y2Namespace *ns, string module, string function);
+
+protected:
+
+    /**
+     * Protected constructor. Use one of the static methods rather than
+     * instantiate an object of this class yourself.
+     **/
+    YPython();
+
+    /**
+     * Destructor.
+     **/
+    ~YPython();
+
+    
+
+
+};
+
+
+#endif	// YPython_h

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -187,14 +187,11 @@ YPythonNamespace::YPythonNamespace (string name)
   //check each symbol and try to find function names
   for (int i = 0; i < num_fun_names; i++) {
     PyObject* pFunc;        //pionter for function from python
-    //y2milestone ("YPythonNamespace iteration %d from all %d", i, num_fun_names);
     item = PyList_GetItem(fun_names, i); /* Can’t fail */
-    //y2milestone ("YPythonNamespace item: %s", PyString_AsString(item));
     if (!PyStr_Check(item)){
       continue;
     }
     pFunc_name = PyStr_AsString(item);
-    //y2milestone ("item: %s", PyString_AsString(item));
     pFunc = PyDict_GetItemString(pMainDict, pFunc_name);
     //check if symbol is callable    
 
@@ -268,17 +265,14 @@ YCPValue YPythonNamespace::evaluate (bool cse)
 Y2Function* YPythonNamespace::createFunctionCall (const string name, constFunctionTypePtr required_type)
 {
     y2debug ("Python creating function call for %s", name.c_str ());
-    //TableEntry *func_te = table ()->find (name.c_str (), SymbolEntry::c_function);
     TableEntry *func_te = table ()->find (name.c_str ());
 
     if (func_te)
     {
-        //cout << "namespace: " << m_name << " function: " << name << endl;
 	constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
 	return new  Y2PythonFunctionCall(m_name, name, t);
     }
     
-    //cout << "namespace: " << m_name << " function: " << name << endl;
     y2error ("No such function %s", name.c_str ());
     return NULL;
 }

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  *
  * This is the path from YCP to Python.
  */
@@ -44,35 +44,38 @@ class Y2PythonFunctionCall : public Y2Function
 
 public:
     Y2PythonFunctionCall (const string &module_name,
-			 const string &local_name,
-                         constFunctionTypePtr function_type
-	) :
-	m_module_name (module_name),
-	m_local_name (local_name),
-	m_type (function_type)
-	{
-	    // placeholder, formerly function name
-	    m_call->add (YCPVoid ());
-	}
+                          const string &local_name,
+                          constFunctionTypePtr function_type
+                         ) :
+        m_module_name (module_name),
+        m_local_name (local_name),
+        m_type (function_type)
+    {
+        // placeholder, formerly function name
+        m_call->add (YCPVoid ());
+    }
 
-    virtual bool isMethod () { return true; }
+    virtual bool isMethod ()
+    {
+        return true;
+    }
 
     //! called by YEFunction::evaluate
     virtual YCPValue evaluateCall ()
     {
-	return YPython::yPython().callInner (
-	    m_module_name, m_local_name, isMethod (),
-	    m_call);
+        return YPython::yPython().callInner (
+                   m_module_name, m_local_name, isMethod (),
+                   m_call);
     }
-    
-       /**
-     * Attaches a parameter to a given position to the call.
-     * @return false if there was a type mismatch
-     */
+
+    /**
+    * Attaches a parameter to a given position to the call.
+    * @return false if there was a type mismatch
+    */
     virtual bool attachParameter (const YCPValue& arg, const int position)
     {
-	m_call->set (position+1, arg);
-	return true;
+        m_call->set (position+1, arg);
+        return true;
     }
 
     /**
@@ -83,148 +86,155 @@ public:
      */
     virtual constTypePtr wantedParameterType () const
     {
-	// -1 for the function name
-	int params_so_far = m_call->size ()-1;
-	return m_type->parameterType (params_so_far);
+        // -1 for the function name
+        int params_so_far = m_call->size ()-1;
+        return m_type->parameterType (params_so_far);
     }
-     
+
     /**
      * Appends a parameter to the call.
      * @return false if there was a type mismatch
      */
     virtual bool appendParameter (const YCPValue& arg)
     {
-	m_call->add (arg);
-	return true;
+        m_call->add (arg);
+        return true;
     }
 
     /**
      * Signal that we're done adding parameters.
      * @return false if there was a parameter missing
      */
-    virtual bool finishParameters () { return true; }
+    virtual bool finishParameters ()
+    {
+        return true;
+    }
 
 
     virtual bool reset ()
     {
-	m_call = YCPList ();
-	// placeholder, formerly function name
-	m_call->add (YCPVoid ());
-	return true;
+        m_call = YCPList ();
+        // placeholder, formerly function name
+        m_call->add (YCPVoid ());
+        return true;
     }
 
     /**
      * Something for remote namespaces
      */
-    virtual string name () const { return m_local_name; }
+    virtual string name () const
+    {
+        return m_local_name;
+    }
 };
 
 SymbolEntry * YPythonNamespace::insertFuncSymbol(PyObject *pFunc, const char *pFunc_name, int& count)
 {
-   FunctionTypePtr sym_tp;
-   //Declarations (using YPCDelcarations python module)
-   YCPDeclarations *decl = YCPDeclarations::instance();
-   //code of function
-   PyObject * fun_code = PyFunction_GetCode(pFunc);
-   //number of function arguments
-   long num = ((PyCodeObject *) fun_code)->co_argcount;
-   if (decl->exists((PyFunctionObject *)pFunc)
-      && decl->numParams((PyFunctionObject *)pFunc) == num){
+    FunctionTypePtr sym_tp;
+    //Declarations (using YPCDelcarations python module)
+    YCPDeclarations *decl = YCPDeclarations::instance();
+    //code of function
+    PyObject * fun_code = PyFunction_GetCode(pFunc);
+    //number of function arguments
+    long num = ((PyCodeObject *) fun_code)->co_argcount;
+    if (decl->exists((PyFunctionObject *)pFunc)
+            && decl->numParams((PyFunctionObject *)pFunc) == num) {
 
-      sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)pFunc));
-      std::vector<constTypePtr> list_of_types =
-         decl->params((PyFunctionObject *)pFunc);
-      int tmp = list_of_types.size();
-      for (int i=0; i < tmp; i++){
-         sym_tp->concat(list_of_types[i]);
-      }
-   } else {
-      sym_tp = new FunctionType(Type::Any);
-      //add types and number of arguments into SymbolEntry table
-      for (long j = 0; j < num; j++) {
-         sym_tp->concat(Type::Any);
-      }
-   }
-   // symbol entry for the function
-   SymbolEntry *fun_se = new SymbolEntry (this,
-                // position. arbitrary numbering. must stay consistent when?
-                count++,
-                // passed to Ustring, no need to strdup
-		pFunc_name,
-		SymbolEntry::c_function,
-		sym_tp);
-   fun_se->setGlobal (true);
+        sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)pFunc));
+        std::vector<constTypePtr> list_of_types =
+            decl->params((PyFunctionObject *)pFunc);
+        int tmp = list_of_types.size();
+        for (int i=0; i < tmp; i++) {
+            sym_tp->concat(list_of_types[i]);
+        }
+    } else {
+        sym_tp = new FunctionType(Type::Any);
+        //add types and number of arguments into SymbolEntry table
+        for (long j = 0; j < num; j++) {
+            sym_tp->concat(Type::Any);
+        }
+    }
+    // symbol entry for the function
+    SymbolEntry *fun_se = new SymbolEntry (this,
+                                           // position. arbitrary numbering. must stay consistent when?
+                                           count++,
+                                           // passed to Ustring, no need to strdup
+                                           pFunc_name,
+                                           SymbolEntry::c_function,
+                                           sym_tp);
+    fun_se->setGlobal (true);
 
-   // enter it to the symbol table
-   enterSymbol (fun_se, 0);
-   return fun_se;
+    // enter it to the symbol table
+    enterSymbol (fun_se, 0);
+    return fun_se;
 }
 
 YPythonNamespace::YPythonNamespace (string name)
     : m_name (name)
 {
-  //Objects for Python API
-  PyObject* pMainDict;    //global dictionary of imported module
-  const char* pFunc_name;
-  PyObject* item;         //item from dictionary
-  PyObject * fun_names;   //list of keys from dictionary (YPython::yPython()->pMain())
+    //Objects for Python API
+    PyObject* pMainDict;    //global dictionary of imported module
+    const char* pFunc_name;
+    PyObject* item;         //item from dictionary
+    PyObject * fun_names;   //list of keys from dictionary (YPython::yPython()->pMain())
 
-  int num_fun_names = 0; //number of keys from dictionary
-  int count = 0;         // position. arbitrary numbering
+    int num_fun_names = 0; //number of keys from dictionary
+    int count = 0;         // position. arbitrary numbering
 
-  //obtain main dictionary of globals variables
-  pMainDict = PyDict_GetItemString(YPython::yPython().pMainDicts(),name.c_str());
-  if (pMainDict == NULL){
-      y2error("Can't load module %s", name.c_str());
-      return;
-  }
-
-  //keys from dictionary
-  fun_names = PyDict_Keys(pMainDict);
-
-  //number of symbols
-  num_fun_names = PyList_Size(fun_names);
-  //check each symbol and try to find function names
-  for (int i = 0; i < num_fun_names; i++) {
-    PyObject* pFunc;        //pionter for function from python
-    item = PyList_GetItem(fun_names, i); /* Can’t fail */
-    if (!PyStr_Check(item)){
-      continue;
+    //obtain main dictionary of globals variables
+    pMainDict = PyDict_GetItemString(YPython::yPython().pMainDicts(),name.c_str());
+    if (pMainDict == NULL) {
+        y2error("Can't load module %s", name.c_str());
+        return;
     }
-    pFunc_name = PyStr_AsString(item);
-    pFunc = PyDict_GetItemString(pMainDict, pFunc_name);
-    //check if symbol is callable    
 
-    if (PyFunction_Check(pFunc)) {
-        insertFuncSymbol(pFunc, pFunc_name, count);
-    }
-  } // end of for (int i = 0; i < num_fun_names; i++)
+    //keys from dictionary
+    fun_names = PyDict_Keys(pMainDict);
 
-  y2milestone ("YPythonNamespace finish");
+    //number of symbols
+    num_fun_names = PyList_Size(fun_names);
+    //check each symbol and try to find function names
+    for (int i = 0; i < num_fun_names; i++) {
+        PyObject* pFunc;        //pionter for function from python
+        item = PyList_GetItem(fun_names, i); /* Can’t fail */
+        if (!PyStr_Check(item)) {
+            continue;
+        }
+        pFunc_name = PyStr_AsString(item);
+        pFunc = PyDict_GetItemString(pMainDict, pFunc_name);
+        //check if symbol is callable
+
+        if (PyFunction_Check(pFunc)) {
+            insertFuncSymbol(pFunc, pFunc_name, count);
+        }
+    } // end of for (int i = 0; i < num_fun_names; i++)
+
+    y2milestone ("YPythonNamespace finish");
 
 }
 
 
 YPythonNamespace::YPythonNamespace (string name, PyObject* function)
-      : m_name (name)
+    : m_name (name)
 {
-  int count = 0;         // position. arbitrary numbering
+    int count = 0;         // position. arbitrary numbering
 
-  PyObject * fun_code = PyFunction_GetCode(function);
-  const char* pFunc_name;
-  pFunc_name = PyStr_AsString(((PyCodeObject *) fun_code)->co_name);
-  insertFuncSymbol(fun_code, pFunc_name, count);
-  y2milestone ("(special) YPythonNamespace finish");
+    PyObject * fun_code = PyFunction_GetCode(function);
+    const char* pFunc_name;
+    pFunc_name = PyStr_AsString(((PyCodeObject *) fun_code)->co_name);
+    insertFuncSymbol(fun_code, pFunc_name, count);
+    y2milestone ("(special) YPythonNamespace finish");
 
 }
 
-SymbolEntry * YPythonNamespace::AddFunction (PyObject* function) {
+SymbolEntry * YPythonNamespace::AddFunction (PyObject* function)
+{
 
-  PyObject *fun_code = PyFunction_GetCode(function);
-  const char * fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
-  int count = 0;
+    PyObject *fun_code = PyFunction_GetCode(function);
+    const char * fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+    int count = 0;
 
-  return insertFuncSymbol(function, fun_name, count);
+    return insertFuncSymbol(function, fun_name, count);
 }
 
 
@@ -245,8 +255,8 @@ string YPythonNamespace::toString () const
 {
     y2error ("TODO");
     return "{\n"
-	"/* this namespace is provided in Python */\n"
-	"}\n";
+           "/* this namespace is provided in Python */\n"
+           "}\n";
 }
 
 // called when running and the import statement is encountered
@@ -267,12 +277,11 @@ Y2Function* YPythonNamespace::createFunctionCall (const string name, constFuncti
     y2debug ("Python creating function call for %s", name.c_str ());
     TableEntry *func_te = table ()->find (name.c_str ());
 
-    if (func_te)
-    {
-	constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
-	return new  Y2PythonFunctionCall(m_name, name, t);
+    if (func_te) {
+        constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
+        return new  Y2PythonFunctionCall(m_name, name, t);
     }
-    
+
     y2error ("No such function %s", name.c_str ());
     return NULL;
 }

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -1,0 +1,395 @@
+/**
+ * 
+ *
+ * This is the path from YCP to Python.
+ */
+
+#include <Python.h>
+#include "YPythonNamespace.h"
+
+#define y2log_component "Y2PythonNamespace"
+#include <ycp/y2log.h>
+#include <ycp/pathsearch.h>
+
+#include <ycp/YCPElement.h>
+#include <ycp/Type.h>
+#include <ycp/YCPVoid.h>
+
+#include <YPython.h>
+#include <stdio.h>
+
+#include "YCPDeclarations.h"
+#define DBG(str) \
+    std::cerr << __FILE__ << ": " << __LINE__ << ": " << str << std::endl; \
+    std::cerr.flush()
+
+
+
+/**
+ * The definition of a function that is implemented in Perl
+ */
+class Y2PythonFunctionCall : public Y2Function
+{
+    //! module name
+    string m_module_name;
+    //! function name, excluding module name
+    string m_local_name;
+    //! function type
+    constFunctionTypePtr m_type;
+    //! data prepared for the inner call
+    YCPList m_call;
+
+public:
+    Y2PythonFunctionCall (const string &module_name,
+			 const string &local_name,
+                         constFunctionTypePtr function_type
+	) :
+	m_module_name (module_name),
+	m_local_name (local_name),
+	m_type (function_type)
+	{
+	    // placeholder, formerly function name
+	    m_call->add (YCPVoid ());
+	}
+
+    //! if true, the python function is passed the module name
+    virtual bool isMethod () = 0;
+
+    //! called by YEFunction::evaluate
+    virtual YCPValue evaluateCall ()
+    {
+	return YPython::yPython()->callInner (
+	    m_module_name, m_local_name, isMethod (),
+	    m_call);
+    }
+    
+       /**
+     * Attaches a parameter to a given position to the call.
+     * @return false if there was a type mismatch
+     */
+    virtual bool attachParameter (const YCPValue& arg, const int position)
+    {
+	m_call->set (position+1, arg);
+	return true;
+    }
+
+    /**
+     * What type is expected for the next appendParameter (val) ?
+     * (Used when calling from Perl, to be able to convert from the
+     * simple type system of Perl to the elaborate type system of YCP)
+     * @return Type::Any if number of parameters exceeded
+     */
+    virtual constTypePtr wantedParameterType () const
+    {
+	// -1 for the function name
+	int params_so_far = m_call->size ()-1;
+	return m_type->parameterType (params_so_far);
+    }
+     
+    /**
+     * Appends a parameter to the call.
+     * @return false if there was a type mismatch
+     */
+    virtual bool appendParameter (const YCPValue& arg)
+    {
+	m_call->add (arg);
+	return true;
+    }
+
+    /**
+     * Signal that we're done adding parameters.
+     * @return false if there was a parameter missing
+     */
+    virtual bool finishParameters () { return true; }
+
+
+    virtual bool reset ()
+    {
+	m_call = YCPList ();
+	// placeholder, formerly function name
+	m_call->add (YCPVoid ());
+	return true;
+    }
+
+    /**
+     * Something for remote namespaces
+     */
+    virtual string name () const { return m_local_name; }
+};
+
+class Y2PythonSubCall : public Y2PythonFunctionCall {
+public:
+    Y2PythonSubCall (const string &module_name,
+		     const string &local_name,
+		     constFunctionTypePtr function_type 
+	) :
+	Y2PythonFunctionCall (module_name, local_name, function_type)
+	{}
+    virtual bool isMethod () { return false; }
+};
+
+class Y2PythonMethodCall : public Y2PythonFunctionCall {
+public:
+    Y2PythonMethodCall (const string &module_name,
+			const string &local_name,
+                        constFunctionTypePtr function_type
+	) :
+	Y2PythonFunctionCall (module_name, local_name, function_type)
+	{}
+    virtual bool isMethod () { return true; }
+};
+
+
+
+YPythonNamespace::YPythonNamespace (string name)
+    : m_name (name),
+      m_all_methods (true)
+{
+
+  //Objects for Python API
+  PyObject* pMainDict;    //global dictionary of imported module
+  PyObject* pFunc;        //pionter for function from python
+  PyObject* item;         //item from dictionary
+  PyObject * fun_names;   //list of keys from dictionary (YPython::yPython()->pMain())
+  PyObject * fun_code;    //code of function
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  //YCPDeclarations *decl = new YCPDeclarations();
+  
+  FunctionTypePtr sym_tp;
+  std::vector<constTypePtr> list_of_types;
+  int tmp;
+
+
+  int num_fun_names = 0; //number of keys from dictionary
+  int count = 0;         // position. arbitrary numbering
+  long num = 0;          //number of function arguments
+
+  //obtain main dictionary of globals variables
+  pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),name.c_str());
+  if (pMainDict == NULL){
+      y2error("Can't load module %s", name.c_str());
+      return;
+  }
+
+  //keys from dictionary
+  fun_names = PyDict_Keys(pMainDict);
+
+  //number of symbols
+  num_fun_names = PyList_Size(fun_names);
+  //check each symbol and try to find function names
+  for (int i = 0; i < num_fun_names; i++) {
+    //y2milestone ("YPythonNamespace iteration %d from all %d", i, num_fun_names);
+    item = PyList_GetItem(fun_names, i); /* Can’t fail */
+    //y2milestone ("YPythonNamespace item: %s", PyString_AsString(item));
+    if (!PyString_Check(item)) continue; /* Skip non-string */
+    //y2milestone ("item: %s", PyString_AsString(item));
+    pFunc = PyDict_GetItemString(pMainDict,PyString_AsString(item));    
+    //check if symbol is callable    
+
+    if (PyFunction_Check(pFunc)) {
+       fun_code = PyFunction_GetCode(pFunc);
+       num = ((PyCodeObject *) fun_code)->co_argcount;
+
+         
+       if (decl->exists((PyFunctionObject *)pFunc) 
+           && decl->numParams((PyFunctionObject *)pFunc) == num){
+
+           sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)pFunc));
+
+           list_of_types = decl->params((PyFunctionObject *)pFunc);
+           tmp = list_of_types.size();
+           for (int i=0; i < tmp; i++){
+               sym_tp->concat(list_of_types[i]);
+           }
+       }else{
+           sym_tp = new FunctionType(Type::Any);
+           //y2milestone ("Number of parameters: %d", num);
+           //add types and number of arguments into SymbolEntry table
+           for (long j = 0; j < num; j++) {
+               sym_tp->concat(Type::Any);    
+           }
+       }
+       //y2milestone ("Callable function %s", PyString_AsString(item));
+       // symbol entry for the function
+       SymbolEntry *fun_se = new SymbolEntry (
+		this,
+		count++,	         // position. arbitrary numbering. must stay consistent when?
+		PyString_AsString(item), // passed to Ustring, no need to strdup
+		SymbolEntry::c_function, 
+		sym_tp);
+       fun_se->setGlobal (true);
+
+       // enter it to the symbol table
+       enterSymbol (fun_se, 0);
+    }
+  } // end of for (int i = 0; i < num_fun_names; i++)
+
+  y2milestone ("YPythonNamespace finish");
+  
+}
+
+
+YPythonNamespace::YPythonNamespace (string name, PyObject* function)
+      : m_name (name),
+        m_all_methods (true) {
+
+
+  PyObject * fun_code;    //code of function
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  //YCPDeclarations *decl = new YCPDeclarations();
+  
+  FunctionTypePtr sym_tp;
+  std::vector<constTypePtr> list_of_types;
+  int tmp;
+
+  int count = 0;         // position. arbitrary numbering
+  long num = 0;          //number of function arguments
+
+
+  fun_code = PyFunction_GetCode(function);
+  num = ((PyCodeObject *) fun_code)->co_argcount;
+  string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+         
+  if (decl->exists((PyFunctionObject *)function) 
+      && decl->numParams((PyFunctionObject *)function) == num){
+
+     sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)function));
+
+     list_of_types = decl->params((PyFunctionObject *)function);
+     tmp = list_of_types.size();
+     for (int i=0; i < tmp; i++){
+         sym_tp->concat(list_of_types[i]);
+     }
+  } else {
+     sym_tp = new FunctionType(Type::Any);
+     //y2milestone ("Number of parameters: %d", num);
+     //add types and number of arguments into SymbolEntry table
+     for (long j = 0; j < num; j++) {
+         sym_tp->concat(Type::Any);    
+     }
+  }
+  //y2milestone ("Callable function %s", PyString_AsString(item));
+  // symbol entry for the function
+  SymbolEntry *fun_se = new SymbolEntry (
+	this,
+	count++,	         // position. arbitrary numbering. must stay consistent when?
+	fun_name.c_str(), // passed to Ustring, no need to strdup
+	SymbolEntry::c_function, 
+	sym_tp);
+  fun_se->setGlobal (true);
+
+  // enter it to the symbol table
+  enterSymbol (fun_se, 0);
+
+
+  y2milestone ("(special) YPythonNamespace finish");
+
+}
+
+SymbolEntry * YPythonNamespace::AddFunction (PyObject* function) {
+
+  //Declarations (using YPCDelcarations python module)
+  YCPDeclarations *decl = YCPDeclarations::instance();
+  int tmp;
+  std::vector<constTypePtr> list_of_types;
+  FunctionTypePtr sym_tp;
+  PyObject *fun_code = PyFunction_GetCode(function);
+  int num = ((PyCodeObject *) fun_code)->co_argcount;
+  string fun_name = PyString_AsString(((PyCodeObject *) fun_code)->co_name);
+         
+  if (decl->exists((PyFunctionObject *)function) 
+      && decl->numParams((PyFunctionObject *)function) == num){
+
+     sym_tp = new FunctionType(decl->returnType((PyFunctionObject *)function));
+
+     list_of_types = decl->params((PyFunctionObject *)function);
+     tmp = list_of_types.size();
+     for (int i=0; i < tmp; i++){
+         sym_tp->concat(list_of_types[i]);
+     }
+  } else {
+     sym_tp = new FunctionType(Type::Any);
+     //y2milestone ("Number of parameters: %d", num);
+     //add types and number of arguments into SymbolEntry table
+     for (long j = 0; j < num; j++) {
+         sym_tp->concat(Type::Any);    
+     }
+  }
+  // symbol entry for the function
+  SymbolEntry *fun_se = new SymbolEntry (
+	this,
+	0,	        // position. arbitrary numbering. must stay consistent when?
+	fun_name.c_str(),       // passed to Ustring, no need to strdup
+	SymbolEntry::c_function, 
+	sym_tp);
+
+  fun_se->setGlobal (true);
+
+  enterSymbol (fun_se, 0);
+
+  return fun_se;
+}
+
+
+YPythonNamespace::~YPythonNamespace ()
+{
+
+
+}
+
+const string YPythonNamespace::filename () const
+{
+    // TODO improve
+    return ".../" + m_name;
+}
+
+// this is for error reporting only?
+string YPythonNamespace::toString () const
+{
+    y2error ("TODO");
+    return "{\n"
+	"/* this namespace is provided in Python */\n"
+	"}\n";
+}
+
+// called when running and the import statement is encountered
+// does initialization of variables
+// constructor is handled separately after this
+YCPValue YPythonNamespace::evaluate (bool cse)
+{
+    // so we don't need to do anything
+    y2debug ("Doing nothing");
+    return YCPNull ();
+}
+
+
+// It seems that this is the standard implementation. why would we
+// ever want it to be different?
+Y2Function* YPythonNamespace::createFunctionCall (const string name, constFunctionTypePtr required_type)
+{
+    y2debug ("Python creating function call for %s", name.c_str ());
+    //TableEntry *func_te = table ()->find (name.c_str (), SymbolEntry::c_function);
+    TableEntry *func_te = table ()->find (name.c_str ());
+
+    if (func_te)
+    {
+        //cout << "namespace: " << m_name << " function: " << name << endl;
+	constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
+	if (m_all_methods)
+	{
+	    return new Y2PythonMethodCall (m_name, name, t);
+	}
+	else
+	{
+	    return new Y2PythonSubCall (m_name, name, t);
+	}
+    }
+    
+    //cout << "namespace: " << m_name << " function: " << name << endl;
+    y2error ("No such function %s", name.c_str ());
+    return NULL;
+}

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -55,8 +55,7 @@ public:
 	    m_call->add (YCPVoid ());
 	}
 
-    //! if true, the python function is passed the module name
-    virtual bool isMethod () = 0;
+    virtual bool isMethod () { return true; }
 
     //! called by YEFunction::evaluate
     virtual YCPValue evaluateCall ()
@@ -120,33 +119,8 @@ public:
     virtual string name () const { return m_local_name; }
 };
 
-class Y2PythonSubCall : public Y2PythonFunctionCall {
-public:
-    Y2PythonSubCall (const string &module_name,
-		     const string &local_name,
-		     constFunctionTypePtr function_type 
-	) :
-	Y2PythonFunctionCall (module_name, local_name, function_type)
-	{}
-    virtual bool isMethod () { return false; }
-};
-
-class Y2PythonMethodCall : public Y2PythonFunctionCall {
-public:
-    Y2PythonMethodCall (const string &module_name,
-			const string &local_name,
-                        constFunctionTypePtr function_type
-	) :
-	Y2PythonFunctionCall (module_name, local_name, function_type)
-	{}
-    virtual bool isMethod () { return true; }
-};
-
-
-
 YPythonNamespace::YPythonNamespace (string name)
-    : m_name (name),
-      m_all_methods (true)
+    : m_name (name)
 {
 
   //Objects for Python API
@@ -239,8 +213,8 @@ YPythonNamespace::YPythonNamespace (string name)
 
 
 YPythonNamespace::YPythonNamespace (string name, PyObject* function)
-      : m_name (name),
-        m_all_methods (true) {
+      : m_name (name)
+{
 
 
   PyObject * fun_code;    //code of function
@@ -386,14 +360,7 @@ Y2Function* YPythonNamespace::createFunctionCall (const string name, constFuncti
     {
         //cout << "namespace: " << m_name << " function: " << name << endl;
 	constTypePtr t = required_type ? required_type : (constFunctionTypePtr)func_te->sentry()->type ();
-	if (m_all_methods)
-	{
-	    return new Y2PythonMethodCall (m_name, name, t);
-	}
-	else
-	{
-	    return new Y2PythonSubCall (m_name, name, t);
-	}
+	return new  Y2PythonFunctionCall(m_name, name, t);
     }
     
     //cout << "namespace: " << m_name << " function: " << name << endl;

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -61,7 +61,7 @@ public:
     //! called by YEFunction::evaluate
     virtual YCPValue evaluateCall ()
     {
-	return YPython::yPython()->callInner (
+	return YPython::yPython().callInner (
 	    m_module_name, m_local_name, isMethod (),
 	    m_call);
     }
@@ -171,7 +171,7 @@ YPythonNamespace::YPythonNamespace (string name)
   long num = 0;          //number of function arguments
 
   //obtain main dictionary of globals variables
-  pMainDict = PyDict_GetItemString(YPython::yPython()->pMainDicts(),name.c_str());
+  pMainDict = PyDict_GetItemString(YPython::yPython().pMainDicts(),name.c_str());
   if (pMainDict == NULL){
       y2error("Can't load module %s", name.c_str());
       return;

--- a/src/YPythonNamespace.cc
+++ b/src/YPythonNamespace.cc
@@ -187,13 +187,10 @@ YPythonNamespace::YPythonNamespace (string name)
     //y2milestone ("YPythonNamespace iteration %d from all %d", i, num_fun_names);
     item = PyList_GetItem(fun_names, i); /* Can’t fail */
     //y2milestone ("YPythonNamespace item: %s", PyString_AsString(item));
-#if PY_MAJOR_VERSION >= 3
-    if (!PyUnicode_Check(item)) continue;
-    pFunc_name = _PyUnicode_AsString(item);
-#else
-    if (!PyString_Check(item)) continue; /* Skip non-string */
-    pFunc_name = PyString_AsString(item);
-#endif
+    if (!PyStr_Check(item)){
+      continue;
+    }
+    pFunc_name = PyStr_AsString(item);
     //y2milestone ("item: %s", PyString_AsString(item));
     pFunc = PyDict_GetItemString(pMainDict, pFunc_name);
     //check if symbol is callable    

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -1,0 +1,53 @@
+// -*- c++ -*-
+#include <Python.h>
+#include <y2/Y2Namespace.h>
+#include <y2/Y2Function.h>
+#include <ycp/YStatement.h>
+
+/**
+ * YaST interface to a Python module
+ */
+class YPythonNamespace : public Y2Namespace
+{
+private:
+    string m_name;		//! this namespace's name, eg. XML::Writer
+    bool m_all_methods;		//! add the class name to all calls
+public:
+
+    /**
+     * Construct an interface. The module must be already loaded
+     * @param name eg "XML::Writer"
+     */
+    YPythonNamespace (string name);
+
+    /**
+     * Construct an interface. The module must be already loaded
+     * special contruct for calling python function such as reference
+     * @param name eg "XML::Writer"
+     * @param function function defined in python
+     */
+    YPythonNamespace (string name, PyObject* function);
+
+    /**
+     * Add new function into namespace
+     * @param Y2Namespace pointer to namespace for adding function
+     * @param PyObject pointer to function
+     * @return SymbolEntry pointer to added symbol entry else NULL (if failed)
+     */
+    SymbolEntry * AddFunction (PyObject* function);
+
+    virtual ~YPythonNamespace ();
+
+    //! what namespace do we implement
+    virtual const string name () const { return m_name; }
+    //! used for error reporting
+    virtual const string filename () const;
+
+    //! unparse. useful  only for YCP namespaces??
+    virtual string toString () const;
+    //! called when evaluating the import statement
+    // constructor is handled separately
+    virtual YCPValue evaluate (bool cse = false);
+
+    virtual Y2Function* createFunctionCall (const string name, constFunctionTypePtr requiredType);
+};

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -40,7 +40,10 @@ public:
     virtual ~YPythonNamespace ();
 
     //! what namespace do we implement
-    virtual const string name () const { return m_name; }
+    virtual const string name () const
+    {
+        return m_name;
+    }
     //! used for error reporting
     virtual const string filename () const;
 

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -11,7 +11,6 @@ class YPythonNamespace : public Y2Namespace
 {
 private:
     string m_name;		//! this namespace's name, eg. XML::Writer
-    bool m_all_methods;		//! add the class name to all calls
 public:
 
     /**

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -11,7 +11,7 @@ class YPythonNamespace : public Y2Namespace
 {
 private:
     string m_name;		//! this namespace's name, eg. XML::Writer
-    void insertFuncSymbol(PyObject *pFunc, const char *pFunc_name, int& count);
+    SymbolEntry * insertFuncSymbol(PyObject *pFunc, const char *pFunc_name, int& count);
 
 public:
 

--- a/src/YPythonNamespace.h
+++ b/src/YPythonNamespace.h
@@ -11,6 +11,8 @@ class YPythonNamespace : public Y2Namespace
 {
 private:
     string m_name;		//! this namespace's name, eg. XML::Writer
+    void insertFuncSymbol(PyObject *pFunc, const char *pFunc_name, int& count);
+
 public:
 
     /**

--- a/src/compat.h
+++ b/src/compat.h
@@ -10,7 +10,7 @@
 #define PyString_FromString(x) PyUnicode_FromString(x)
 #define PyString_Format(fmt, args)  PyUnicode_Format(fmt, args)
 #define PyString_AsString(str) PyBytes_AsString(str)
-#define PyString_Size(str) PyBytes_Size(str)    
+#define PyString_Size(str) PyBytes_Size(str)
 #define PyString_InternFromString(key) PyUnicode_InternFromString(key)
 #define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
 #define PyString_AS_STRING(x) PyUnicode_AS_STRING(x)

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,19 @@
+/* Compatibility macros for Python 3 */
+#if PY_VERSION_HEX >= 0x03000000
+
+#define PyClass_Check(obj) PyObject_IsInstance(obj, (PyObject *)&PyType_Type)
+#define PyInt_Check(x) PyLong_Check(x)
+#define PyInt_AsLong(x) PyLong_AsLong(x)
+#define PyInt_FromLong(x) PyLong_FromLong(x)
+#define PyInt_FromSize_t(x) PyLong_FromSize_t(x)
+#define PyString_Check(name) PyBytes_Check(name)
+#define PyString_FromString(x) PyUnicode_FromString(x)
+#define PyString_Format(fmt, args)  PyUnicode_Format(fmt, args)
+#define PyString_AsString(str) PyBytes_AsString(str)
+#define PyString_Size(str) PyBytes_Size(str)    
+#define PyString_InternFromString(key) PyUnicode_InternFromString(key)
+#define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
+#define PyString_AS_STRING(x) PyUnicode_AS_STRING(x)
+#define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
+
+#endif

--- a/src/compat.h
+++ b/src/compat.h
@@ -15,5 +15,10 @@
 #define Py_TPFLAGS_HAVE_CLASS Py_TPFLAGS_BASETYPE
 #define PyString_AS_STRING(x) PyUnicode_AS_STRING(x)
 #define _PyLong_FromSsize_t(x) PyLong_FromSsize_t(x)
-
+#define PyStr_AsString PyUnicode_AsUTF8
+#define PyStr_Check PyUnicode_Check
+#else
+/* Compatibility macros for Python 2 */
+#define PyStr_AsString PyString_AsString
+#define PyStr_Check PyString_Check
 #endif

--- a/src/yast-core.i
+++ b/src/yast-core.i
@@ -13,6 +13,7 @@ using namespace std;
 
 %{
 #include "yast.h"
+#include "YPython.h"
 #include "YPythonCode.h"
 #include <ycp/YCPByteblock.h>
 %}

--- a/src/yast.cpp
+++ b/src/yast.cpp
@@ -10,7 +10,7 @@ bool widget_names()
     return true;
 }
 
-static Y2Namespace * getNs(const char * ns_name)
+Y2Namespace * getNs(const char * ns_name)
 {
     Import import(ns_name); // has a static cache
     Y2Namespace *ns = import.nameSpace();

--- a/src/yast.cpp
+++ b/src/yast.cpp
@@ -59,28 +59,6 @@ YCPValue GetYCPVariable(const string & namespace_name, const string & variable_n
     return sym_entry->value();
 }
 
-/**
- * This is needed for importing new module from ycp.
- */
-#if PY_MAJOR_VERSION >= 3
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    NULL,                /* m_name */
-    NULL,                /* m_doc */
-    -1,                  /* m_size */
-    NULL,                /* m_methods */
-    NULL,                /* m_reload */
-    NULL,                /* m_traverse */
-    NULL,                /* m_clear */
-    NULL,                /* m_free */
-};
-#else
-static PyMethodDef new_module_methods[] =
-{
-    {NULL, NULL, 0, NULL}
-};
-#endif
-
 YCPList * list_functions;
 YCPList * list_variables;
 
@@ -113,12 +91,7 @@ PyObject* import_module(const string & ns_name)
     if (!ns) return Py_None;
 
     // Init new module with name NameSpace and method __run (see new_module_methods)
-#if PY_MAJOR_VERSION >= 3
-    moduledef.m_name = ns_name.c_str();
-    PyObject *new_module = PyModule_Create(&moduledef);
-#else
-    PyObject *new_module = Py_InitModule(ns_name.c_str(), new_module_methods);
-#endif
+    PyObject *new_module = PyModule_New(ns_name.c_str());
     if (new_module == NULL) return Py_None;
 
     // Dictionary of new_module - there will be registered all functions

--- a/src/yast.h
+++ b/src/yast.h
@@ -36,4 +36,4 @@ PyObject* import_module(const string & ns_name);
 
 bool widget_names();
 YCPValue _SCR_Run(char *function, YCPList args);
-
+Y2Namespace * getNs(const char * ns_name);

--- a/src/yast.py.in
+++ b/src/yast.py.in
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import ycpbuiltins
 from ycp import Symbol, List, String, Integer, Boolean, Float, Code, Map, Byteblock, Path, Void
+from YCPDeclarations import YCPDeclare as Declare
 
 from gettext import gettext
 globals()['_'] = gettext

--- a/src/yast.py.in
+++ b/src/yast.py.in
@@ -130,7 +130,6 @@ meta_funcs = {
         'ColoredLabel': False,
         'Dummy': False,
         'DummySpecialWidget': False,
-        'HVStretch': False,
         'IconButton': False,
         'PkgSpecial': False,
         'Wizard': False,

--- a/src/yast.py.in
+++ b/src/yast.py.in
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ycpbuiltins
 from ycp import Symbol, List, String, Integer, Boolean, Float, Code, Map, Byteblock, Path, Void
 from YCPDeclarations import YCPDeclare as Declare
+from yast_help import docs as __docs, scr_docs as __scr_docs
 
 from gettext import gettext
 globals()['_'] = gettext
@@ -40,7 +41,12 @@ class SCR:
     pass
 
 def scr_meta_func_creator(func):
-    return staticmethod(lambda *args : SCR_Run(func, *args))
+    from six import PY2
+    func_ptr = (lambda *args : SCR_Run(func, *args))
+    func_ptr.__name__ = func.encode() if PY2 else func
+    if func in __scr_docs.keys():
+        func_ptr.__doc__ = __scr_docs[func]
+    return staticmethod(func_ptr)
 
 for func in scr_meta_funcs:
     setattr(SCR, func, scr_meta_func_creator(func))
@@ -54,9 +60,12 @@ def run(func, *args):
     return YCPTerm(func, l)
 
 def meta_func_creator(func, lowercase):
-    if lowercase:
-        func = func.lower()
-    return (lambda *args : run(func, *args))
+    from six import PY2
+    func_ptr = (lambda *args : run(func.lower() if lowercase else func, *args))
+    func_ptr.__name__ = func.encode() if PY2 else func
+    if func in __docs.keys():
+        func_ptr.__doc__ = __docs[func]
+    return func_ptr
 
 current_module = __import__(__name__)
 meta_funcs = {

--- a/src/yast.py.in
+++ b/src/yast.py.in
@@ -17,7 +17,7 @@ def import_module(module):
     if m:
         globals()[module] = m
 
-def SCR_Run(func, *args):
+def __SCR_Run(func, *args):
     from ycp import _SCR_Run, pyval_to_ycp
     l = List()
     for item in args:
@@ -42,7 +42,7 @@ class SCR:
 
 def scr_meta_func_creator(func):
     from six import PY2
-    func_ptr = (lambda *args : SCR_Run(func, *args))
+    func_ptr = (lambda *args : __SCR_Run(func, *args))
     func_ptr.__name__ = func.encode() if PY2 else func
     if func in __scr_docs.keys():
         func_ptr.__doc__ = __scr_docs[func]
@@ -51,7 +51,7 @@ def scr_meta_func_creator(func):
 for func in scr_meta_funcs:
     setattr(SCR, func, scr_meta_func_creator(func))
 
-def run(func, *args):
+def __run(func, *args):
     from ycp import pyval_to_ycp
     from ycp import Term as YCPTerm
     l = List()
@@ -61,7 +61,7 @@ def run(func, *args):
 
 def meta_func_creator(func, lowercase):
     from six import PY2
-    func_ptr = (lambda *args : run(func.lower() if lowercase else func, *args))
+    func_ptr = (lambda *args : __run(func.lower() if lowercase else func, *args))
     func_ptr.__name__ = func.encode() if PY2 else func
     if func in __docs.keys():
         func_ptr.__doc__ = __docs[func]
@@ -191,3 +191,4 @@ def Id(arg, dont_force_sym = False):
         l.add(pyval_to_ycp(arg))
     return YCPTerm("id", l)
 
+del absolute_import, division, print_function, unicode_literals

--- a/src/yast_help.py
+++ b/src/yast_help.py
@@ -1,0 +1,1029 @@
+docs = {}
+
+docs['BarGraph'] = \
+    """Horizontal bar graph (optional widget)
+
+    Synopsis
+    BarGraph (	list values , list labels );
+ 
+    Parameters
+    list values  the initial values (integer numbers)
+
+    Optional Arguments
+    list labels  the labels for each part; use "%1" to include the current numeric value. May include newlines.
+    """
+
+docs['BusyIndicator'] = \
+    """Graphical busy indicator
+
+    Synopsis
+    BusyIndicator (	string label , integer timeout );
+ 
+    Parameters
+    string label  the label describing the bar
+
+    Optional Arguments
+    integer timeout  the timeout in milliseconds until busy indicator changes to stalled state, 1000ms by default
+    """
+
+docs['ButtonBox'] = \
+    """Layout for push buttons that takes button order into account
+
+    Synopsis
+    ButtonBox ( term button1, term button2 );
+
+    Parameters
+    term buttons  list of PushButton items
+
+    """
+
+docs['CheckBox'] = \
+    """Clickable on/off toggle button
+
+    Synopsis
+    CheckBox (	string label , boolean|nil checked );
+ 
+    Parameters
+    string label  the text describing the check box
+
+    Options
+    boldFont  use a bold font
+
+    Optional Arguments
+    boolean|nil checked  whether the check box should start checked -
+        nil means tristate condition, i.e. neither on nor off
+    """
+
+docs['CheckBoxFrame'] = \
+    """Frame with clickable on/off toggle button
+
+    Synopsis
+    CheckBoxFrame (	string label , boolean checked , term child );
+ 
+    Parameters
+    string label  the text describing the check box
+    boolean checked  whether the check box should start checked
+    term child  the child widgets for frame content - typically `VBox(...) or `HBox(...)
+
+    Options
+    noAutoEnable  do not enable/disable frame children upon status change
+    invertAutoAnable  disable frame children if check box is checked
+    """
+
+docs['ComboBox'] = \
+    """drop-down list selection (optionally editable)
+
+    Synopsis
+    ComboBox ( string label, list items );
+
+    Parameters
+    string label
+
+    Options
+    editable  the user can enter any value.
+
+    Optional Arguments
+    list items  the items contained in the combo box
+
+    """
+
+docs['DateField'] = \
+    """Date input field
+
+    Synopsis
+    DateField (	string label , string initialDate );
+
+    Parameters
+    string label
+
+    Optional Arguments
+    string initialDate
+    """
+
+docs['DownloadProgress'] = \
+    """Self-polling file growth progress indicator (optional widget)
+
+    Synopsis
+    DownloadProgress (	string label , string filename , integer expectedSize );
+ 
+    Parameters
+    string label  label above the indicator
+    string filename  file name with full path of the file to poll
+    integer expectedSize  expected final size of the file in bytes
+    """
+
+docs['DumbTab'] = \
+    """Simplistic tab widget that behaves like push buttons
+
+    Synopsis
+    DumbTab ( list tabs , term contents );
+
+    Parameters
+    list tabs  page headers
+    term contents  page contents - usually a ReplacePoint
+    """
+
+docs['Empty'] = \
+    """Placeholder widget
+
+    Synopsis
+    Empty (	void);
+    """
+
+docs['Frame'] = \
+    """Frame with label
+
+    Synopsis
+    Frame ( string label, term child );
+
+    Parameters
+    string label  title to be displayed on the top left edge
+    term child  the contained child widget
+
+    """
+
+docs['Graph'] = \
+    """graph
+
+    Synopsis
+    Graph (	void);
+    """
+
+docs['HBox'] = \
+    """Generic layout: Arrange widgets horizontally
+
+    Synopsis
+    HBox ( children... );
+
+    Optional Arguments
+    list children  children widgets
+
+    """
+
+docs['VBox'] = \
+    """Generic layout: Arrange widgets vertically
+
+    Synopsis
+    VBox ( children... );
+
+    Optional Arguments
+    list children  children widgets
+
+    """
+
+docs['HSpacing'] = \
+    """Fixed size empty space for layout
+
+    Synopsis
+    HSpacing ( integer|float size );
+
+    Optional Arguments
+    integer|float size
+
+    """
+
+docs['VSpacing'] = \
+    """Fixed size empty space for layout
+
+    Synopsis
+    VSpacing ( integer|float size );
+
+    Optional Arguments
+    integer|float size
+
+    """
+
+docs['HStretch'] = \
+    """Fixed size empty space for layout
+
+    Synopsis
+    HStretch ( integer|float size );
+
+    Optional Arguments
+    integer|float size
+
+    """
+
+docs['VStretch'] = \
+    """Fixed size empty space for layout
+
+    Synopsis
+    VStretch ( integer|float size );
+
+    Optional Arguments
+    integer|float size
+
+    """
+
+docs['HSquash'] = \
+    """Layout aid: Minimize widget to its preferred size
+
+    Synopsis
+    HSquash (	term child );
+
+    Parameters
+    term child  the child widget
+    """
+
+docs['VSquash'] = \
+    """Layout aid: Minimize widget to its preferred size
+
+    Synopsis
+    VSquash (   term child );
+
+    Parameters
+    term child  the child widget
+    """
+
+docs['HVSquash'] = \
+    """Layout aid: Minimize widget to its preferred size
+
+    Synopsis
+    HVSquash (   term child );
+
+    Parameters
+    term child  the child widget
+    """
+
+docs['HWeight'] = \
+    """Control relative size of layouts
+
+    Synopsis
+    HWeight ( integer weight, term child );
+
+    Parameters
+    integer weight  the new weight of the child widget
+    term child  the child widget
+
+    """
+
+docs['VWeight'] = \
+    """Control relative size of layouts
+
+    Synopsis
+    VWeight ( integer weight, term child );
+
+    Parameters
+    integer weight  the new weight of the child widget
+    term child  the child widget
+
+    """
+
+docs['Image'] = \
+    """Pixmap image
+
+    Synopsis
+    Image (	string imageFileName );
+ 
+    Parameters
+    string imageFileName  file name (with path) of the image to display
+
+    Options
+    animated  show an animated image (MNG, animated GIF)
+    scaleToFit  scale the pixmap so it fits the available space: zoom in or out as needed
+    zeroWidth  make widget report a preferred width of 0
+    zeroHeight  make widget report a preferred height of 0
+    """
+
+docs['InputField'] = \
+    """Input field
+
+    Synopsis
+    InputField ( string label, string defaulttext );
+
+    Parameters
+    string label  the label describing the meaning of the entry
+
+    Options
+    shrinkable  make the input field very small
+
+    Optional Arguments
+    string defaulttext  The text contained in the text entry
+
+    """
+
+docs['TextEntry'] = \
+    """Input field
+
+    Synopsis
+    TextEntry ( string label, string defaulttext );
+
+    Parameters
+    string label  the label describing the meaning of the entry
+
+    Options
+    shrinkable  make the input field very small
+
+    Optional Arguments
+    string defaulttext  The text contained in the text entry
+
+    """
+
+docs['Password'] = \
+    """Input field
+
+    Synopsis
+    Password ( string label, string defaulttext );
+
+    Parameters
+    string label  the label describing the meaning of the entry
+
+    Options
+    shrinkable  make the input field very small
+
+    Optional Arguments
+    string defaulttext  The text contained in the text entry
+
+    """
+
+docs['IntField'] = \
+    """Numeric limited range input field
+
+    Synopsis
+    IntField (	string label , integer minValue , integer maxValue , integer initialValue );
+ 
+    Parameters
+    string label  Explanatory label above the input field
+    integer minValue  minimum value
+    integer maxValue  maximum value
+    integer initialValue  initial value
+    """
+
+docs['Label'] = \
+    """Simple static text
+
+    Synopsis
+    Label ( string label );
+
+    Parameters
+    string label
+
+    Options
+    outputField  make the label look like an input field in read-only mode
+    boldFont  use a bold font
+
+    """
+
+docs['Heading'] = \
+    """Simple static text
+
+    Synopsis
+    Heading ( string label );
+
+    Parameters
+    string label
+
+    Options
+    outputField  make the label look like an input field in read-only mode
+    boldFont  use a bold font
+
+    """
+
+docs['Left'] = \
+    """Layout alignment
+
+    Synopsis
+    Left ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['Right'] = \
+    """Layout alignment
+
+    Synopsis
+    Right ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['Top'] = \
+    """Layout alignment
+
+    Synopsis
+    Top ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['Bottom'] = \
+    """Layout alignment
+
+    Synopsis
+    Bottom ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['HCenter'] = \
+    """Layout alignment
+
+    Synopsis
+    HCenter ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['VCenter'] = \
+    """Layout alignment
+
+    Synopsis
+    VCenter ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['HVCenter'] = \
+    """Layout alignment
+
+    Synopsis
+    HVCenter ( term child, string pixmap );
+
+    Parameters
+    term child  The contained child widget
+
+    Optional Arguments
+    background pixmap
+
+    """
+
+docs['LogView'] = \
+    """scrollable log lines like "tail -f"
+
+    Synopsis
+    LogView (	string label , integer visibleLines , integer maxLines );
+
+    Parameters
+    string label  (above the log lines)
+    integer visibleLines  number of visible lines (without scrolling)
+    integer maxLines  number of log lines to store (use 0 for "all")
+    """
+
+docs['MarginBox'] = \
+    """Margins around one child widget
+
+    Synopsis
+    MarginBox (	float horMargin , float vertMargin , term child );
+ 
+    Parameters
+    float horMargin  margin left and right of the child widget
+    float vertMargin  margin above and below the child widget
+    term child  The contained child widget
+    """
+
+docs['MenuButton'] = \
+    """Button with popup menu
+
+    Synopsis
+    MenuButton (	string label , itemList menu );
+ 
+    Parameters
+    string label
+    itemList menu  items
+    """
+
+docs['MinWidth'] = \
+    """Layout minimum size
+
+    Synopsis
+    MinWidth ( float|integer size, term child );
+
+    Parameters
+    float|integer size  minimum width
+    term child  The contained child widget
+
+    """
+
+docs['MinHeight'] = \
+    """Layout minimum size
+
+    Synopsis
+    MinHeight ( float|integer size, term child );
+
+    Parameters
+    float|integer size  minimum heigh
+    term child  The contained child widget
+
+    """
+
+docs['MinSize'] = \
+    """Layout minimum size
+
+    Synopsis
+    MinSize ( float|integer width, float|integer height, term child );
+
+    Parameters
+    float|integer size  minimum width
+    float|integer size  minimum height
+    term child  The contained child widget
+
+    """
+
+docs['MultiLineEdit'] = \
+    """multiple line text edit field
+
+    Synopsis
+    MultiLineEdit (	string label , string initialValue );
+ 
+    Parameters
+    string label  label above the field
+
+    Optional Arguments
+    string initialValue  the initial contents of the field
+    """
+
+docs['MultiSelectionBox'] = \
+    """Selection box that allows selecton of multiple items
+
+    Synopsis
+    MultiSelectionBox (	string label , list items );
+
+    Parameters
+    string label
+
+    Options
+    shrinkable  make the widget very small
+
+    Optional Arguments
+    list items  the items initially contained in the selection box
+    """
+
+docs['PackageSelector'] = \
+    """Complete software package selection
+
+    Synopsis
+    PackageSelector (	void);	 
+ 
+    Options
+    youMode  start in YOU (YaST Online Update) mode
+    updateMode  start in update mode
+    searchMode  start with the "search" filter view
+    summaryMode  start with the "installation summary" filter view
+    repoMode  start with the "repositories" filter view
+    repoMgr  enable "Repository Manager" menu item
+    confirmUnsupported  user has to confirm all unsupported (non-L3) packages
+
+    Optional Arguments
+    string floppyDevice
+    """
+
+docs['PartitionSplitter'] = \
+    """Hard disk partition splitter tool (optional widget)
+
+    Synopsis
+    PartitionSplitter (	integer usedSize ,
+ 	    integer totalFreeSize ,
+     	integer newPartSize ,
+ 	    integer minNewPartSize ,
+     	integer minFreeSize ,
+ 	    string usedLabel ,
+     	string freeLabel ,
+ 	    string newPartLabel ,
+     	string freeFieldLabel ,
+ 	    string newPartFieldLabel );
+ 
+    Parameters
+    integer usedSize  size of the used part of the partition
+    integer totalFreeSize  total size of the free part of the partition
+        (before the split)
+    integer newPartSize  suggested size of the new partition
+    integer minNewPartSize  minimum size of the new partition
+    integer minFreeSize  minimum free size of the old partition
+    string usedLabel  BarGraph label for the used part of the old partition
+    string freeLabel  BarGraph label for the free part of the old partition
+    string newPartLabel  BarGraph label for the new partition
+    string freeFieldLabel  label for the remaining free space field
+    string newPartFieldLabel  label for the new size field
+    """
+
+docs['PatternSelector'] = \
+    """High-level widget to select software patterns (selections)
+
+    Synopsis
+    PatternSelector (	void);
+    """
+
+docs['ProgressBar'] = \
+    """Graphical progress indicator
+
+    Synopsis
+    ProgressBar (	string label , integer maxvalue , integer progress );
+
+    Parameters
+    string label  the label describing the bar
+
+    Optional Arguments
+    integer maxvalue  the maximum value of the bar
+    integer progress  the current progress value of the bar
+    """
+
+docs['PushButton'] = \
+    """Perform action on click
+
+    Synopsis
+    PushButton ( string label );
+
+    Parameters
+    string label
+
+    Options
+    default  makes this button the dialogs default button
+    helpButton  automatically shows topmost `HelpText
+    okButton  assign the [OK] role to this button (see ButtonBox)
+    cancelButton  assign the [Cancel] role to this button (see ButtonBox)
+    applyButton  assign the [Apply] role to this button (see ButtonBox)
+    customButton  override any other button role assigned to this button
+
+    """
+
+docs['RadioButton'] = \
+    """Clickable on/off toggle button for radio boxes
+
+    Synopsis
+    RadioButton (	string label , boolean selected );
+
+    Parameters
+    string label
+
+    Options
+    boldFont  use a bold font
+
+    Optional Arguments
+    boolean selected
+    """
+
+docs['RadioButtonGroup'] = \
+    """Radio box - select one of many radio buttons
+
+    Synopsis
+    RadioButtonGroup (	term child );
+ 
+    Parameters
+    term child  the child widget
+    """
+
+docs['ReplacePoint'] = \
+    """Pseudo widget to replace parts of a dialog
+
+    Synopsis
+    ReplacePoint ( term child );
+
+    Parameters
+    term child  the child widget
+    """
+
+docs['RichText'] = \
+    """Static text with HTML-like formatting
+
+    Synopsis
+    RichText ( string text );
+
+    Parameters
+    string text
+
+    Options
+    plainText  don't interpret text as HTML
+    autoScrollDown  automatically scroll down for each text change
+    shrinkable  make the widget very small
+
+    """
+
+docs['SelectionBox'] = \
+    """Scrollable list selection
+
+    Synopsis
+    SelectionBox (	string label , list items );
+ 
+    Parameters
+    string label
+
+    Options
+    shrinkable  make the widget very small
+    immediate  make `notify trigger immediately when the selected item changes
+
+    Optional Arguments
+    list items  the items contained in the selection box
+    """
+
+docs['SimplePatchSelector'] = \
+    """Simplified approach to patch selection
+
+    Synopsis
+    SimplePatchSelector (	void);
+    """
+
+docs['Slider'] = \
+    """Numeric limited range input (optional widget)
+
+    Synopsis
+    Slider (	string label ,
+ 	    integer minValue ,
+     	integer maxValue ,
+     	integer initialValue );
+
+    Parameters
+    string label  Explanatory label above the slider
+    integer minValue  minimum value
+    integer maxValue  maximum value
+    integer initialValue  initial value
+    """
+
+docs['Table'] = \
+    """Multicolumn table widget
+
+    Synopsis
+    Table ( term header, list items );
+
+    Parameters
+    term header  the headers of the columns
+
+    Optional Arguments
+    list items  the items contained in the selection box
+
+    """
+
+docs['TimeField'] = \
+    """Time input field
+
+    Synopsis
+    TimeField (	string label , string initialTime );
+
+    Parameters
+    string label
+
+    Optional Arguments
+    string initialTime
+    """
+
+docs['TimezoneSelector'] = \
+    """Timezone selector map
+
+    Synopsis
+    TimezoneSelector (	string pixmap , map timezones );
+
+    Parameters
+    string pixmap  path to a jpg or png of a world map - with being the middle of the picture
+    map timezones  a map of timezones. The map should be between e.g. Europe/London
+        and the tooltip to be displayed ("United Kingdom")
+    """
+
+
+docs['Tree'] = \
+    """Scrollable tree selection
+
+    Synopsis
+    Tree ( string label );
+
+    Parameters
+    string label
+
+    Options
+    immediate  make `notify trigger immediately when the selected item changes
+
+    Optional Arguments
+    itemList items  the items contained in the tree
+
+    """
+
+docs['VMultiProgressMeter'] = \
+    """Progress bar with multiple segments (optional widget)
+
+    Synopsis
+    VMultiProgressMeter (	List<integer> maxValues );
+
+    Parameters
+    List<integer> maxValues  maximum values
+    """
+
+docs['HMultiProgressMeter'] = \
+    """Progress bar with multiple segments (optional widget)
+
+    Synopsis
+    HMultiProgressMeter (   List<integer> maxValues );
+
+    Parameters
+    List<integer> maxValues  maximum values
+    """
+
+docs['IconButton'] = \
+    """Perform action on click
+
+    Synopsis
+    IconButton (	string iconName ,
+                    string label );
+
+    Parameters
+    string iconName
+    string label
+
+    Options
+    default  makes this button the dialogs default button
+    helpButton  automatically shows topmost `HelpText
+    okButton  assign the [OK] role to this button (see ButtonBox)
+    cancelButton  assign the [Cancel] role to this button (see ButtonBox)
+    applyButton  assign the [Apply] role to this button (see ButtonBox)
+    customButton  override any other button role assigned to this button
+    """
+
+docs['ColoredLabel'] = \
+    """Simple static text with specified background and foreground color
+
+    Synopsis
+    ColoredLabel (	string  	label ,
+                    color  	foreground ,
+                    color  	background ,
+                    integer  	margin );
+
+    Parameters
+    string label
+    color foreground
+            color
+
+    color background
+            color
+
+    integer margin
+            around the widget in pixels
+
+    Options
+    boldFont
+            use a bold font
+
+    Properties
+    string Value
+            the label text
+    """
+
+scr_docs = {}
+
+scr_docs['Dir'] = \
+    """Gets array of all children attached directly below path.
+
+    Synopsis
+    Dir(path)
+
+    Parameters
+    string path
+            sub-path where to search for children
+
+    Returns
+    string[]
+            list of children names
+    """
+
+scr_docs['Error'] = \
+    """Gets detailled error description from agent.
+
+    Synopsis
+    Error(path)
+
+    Parameters
+    string path
+            path to agent
+
+    Returns
+    hash
+            with keys "code" and "summary"
+    """
+
+scr_docs['Execute'] = \
+    """Executes command
+
+    Synopsis
+    Execute(path, *args)
+
+    Parameters
+    string path
+            path to agent
+    args
+            additional arguments depending on agent
+    """
+
+scr_docs['Read'] = \
+    """Reads data
+
+    Synopsis
+    Read(path, *args)
+
+    Parameters
+    string path
+            path that is combination of path where agent is attached and path inside agent
+    args
+            additional arguments depending on agent, usually optional
+    """
+
+scr_docs['RegisterAgent'] = \
+    """Register an agent at given path with description
+
+    Synopsis
+    RegisterAgent(path, description)
+
+    Parameters
+    string path
+            path to agent
+    string description
+            path to file description or direct term with agent description
+
+    Returns
+    bool
+            if succeed
+    """
+
+scr_docs['RegisterNewAgents'] = \
+    """Register new agents.
+    Rescan the scrconf registration directories and register any agents at new(!) paths. Agents, even new ones, on paths that are registered already, will not be replaced. This means that .oes.specific.agent will start to work but something like adding /usr/local/etc/sysconfig to .sysconfig.network would not.
+
+    Synopsis
+    RegisterNewAgents()
+
+    Returns
+    bool
+            if succeed
+    """
+
+scr_docs['UnmountAgent'] = \
+    """Unmounts agent. The agent is detached, but when needed it is mounted again automatically.
+
+    It sends to component result() which force to terminate component. If there is any lazy write, then it is properly finished.
+
+    Synopsis
+    UnmountAgent(path)
+
+    Parameters
+    string path
+            path to agent
+    """
+
+scr_docs['UnregisterAgent'] = \
+    """Unregister agent from given path
+
+    Synopsis
+    UnregisterAgent(path)
+
+    Parameters
+    string path
+            path to agent
+
+    Returns
+    bool
+            if succeed
+    """
+
+scr_docs['UnregisterAllAgents'] = \
+    """Unregister all agents
+
+    Synopsis
+    UnregisterAllAgents()
+
+    Returns
+    bool
+            if succeed
+    """
+
+scr_docs['Write'] = \
+    """Writes data
+
+    Synopsis
+    Write(path, *args)
+
+    Parameters
+    string path
+            path that is combination of path where agent is attached and path inside agent
+    args
+            additional arguments depending on agent
+
+    Returns
+    bool
+            if succeed
+    """
+

--- a/src/ycpbuiltins.py
+++ b/src/ycpbuiltins.py
@@ -1,13 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ycp import List, String, Integer, Boolean, Float, Value
-from ycp import Term as YCPTerm
-
-import time, inspect, os
-from random import randint as pyrand_range
-import re
 
 # returns the caller n frames back
 def get_caller_loginfo(frames):
+    import inspect
     frame = inspect.currentframe()
     for i in range(0, frames):
         frame = frame.f_back
@@ -55,11 +50,11 @@ def foreach(listOrMap):
 
 # add - Add a key/value pair to a map or list
 def add(listOrMap, key, value=None):
-    from ycp import pyval_to_ycp
+    from ycp import pyval_to_ycp, List, Term
 
     if isinstance(listOrMap, dict):
         listOrMap[key] = value
-    elif isinstance(listOrMap, List) or isinstance(listOrMap, YCPTerm):
+    elif isinstance(listOrMap, List) or isinstance(listOrMap, Term):
          ycpvalue = pyval_to_ycp(key)
          listOrMap.add(ycpvalue)
     else: # assume list
@@ -68,13 +63,14 @@ def add(listOrMap, key, value=None):
     return listOrMap
 
 def size(listMapOrTerm):
-    if isinstance(listMapOrTerm, YCPTerm):
+    from ycp import Term
+    if isinstance(listMapOrTerm, Term):
         return listMapOrTerm.size()
     # assume list or map 
     return len(listMapOrTerm)
 
 def sleep(millisecs):
-    
+    import time
     time.sleep(float(millisecs)/1000)
 
 def tostring(val):
@@ -122,6 +118,7 @@ def merge(list1, list2):
     return list1 + list2
 
 def random(maxint):
+    from random import randint as pyrand_range
     return pyrand_range(0, maxint)
 
 def mergestring(listofstrings, glue):
@@ -143,5 +140,7 @@ def substring(s, start, num_chars=None):
     return result
 
 def regexpmatch(searchtext, pattern):
+    import re
     return re.search(pattern, searchtext) is not None
 
+del absolute_import, division, print_function, unicode_literals

--- a/src/ytypes.i
+++ b/src/ytypes.i
@@ -45,7 +45,7 @@ YCPValue pyval_to_ycp(PyObject *input)
         }
     }
     if (PyFunction_Check(input))
-        return YPython::yPython()->fromPythonFunToReference(input);
+        return YPython::yPython().fromPythonFunToReference(input);
     if (PyDict_Check(input)) {
         YCPMap m;
         if (PyDict_Size(input) == 0)

--- a/src/ytypes.i
+++ b/src/ytypes.i
@@ -45,7 +45,7 @@ YCPValue pyval_to_ycp(PyObject *input)
         }
     }
     if (PyFunction_Check(input))
-        return YCPCode(new YPythonCode(PyTuple_Pack(1, input)));
+        return YPython::yPython()->fromPythonFunToReference(input);
     if (PyDict_Check(input)) {
         YCPMap m;
         if (PyDict_Size(input) == 0)


### PR DESCRIPTION
Importing python modules from ruby/perl is now possible using this old code that's been re-integrated (and builds via python3).