### PR TITLE
Make python2 binding optional due to its removal

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  9 09:45:58 UTC 2020 - Tomáš Chvátal <tchvatal@suse.com>
+
+- Switch to python3 on new releases of openSUSE as we no longer
+  support python2 at all
+- Cleanup the spec file to adhere to current packaging guidelines
+
+-------------------------------------------------------------------
 Tue May 21 15:58:45 UTC 2019 - dmulder@suse.com
 
 - yast2-python-bindings compilation errors when compiling with

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-python-bindings
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,22 +16,19 @@
 #
 
 
-%if 0%{?suse_version} > 1310 || 0%{?fedora_version} > 20
-%define with_python3 1
+%bcond_without python3
+%if 0%{?suse_version} <= 1500
+%bcond_without python2
 %else
-%define with_python3 0
+%bcond_with python2
 %endif
-
 Name:           yast2-python-bindings
 Version:        4.1.1
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only
 Group:          System/YaST
-
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
-
 BuildRequires:  autoconf
 BuildRequires:  autoconf-archive
 BuildRequires:  automake
@@ -40,11 +37,6 @@ BuildRequires:  libtool
 BuildRequires:  libyui-devel
 BuildRequires:  make
 BuildRequires:  python
-BuildRequires:  python-devel
-%if %{with_python3}
-BuildRequires:  python3
-BuildRequires:  python3-devel
-%endif
 BuildRequires:  python-rpm-macros
 BuildRequires:  swig
 BuildRequires:  yast2-core-devel
@@ -53,78 +45,79 @@ BuildRequires:  yast2-ycp-ui-bindings-devel
 Requires:       python
 Requires:       yast2-core
 Requires:       yast2-ycp-ui-bindings
-Obsoletes:      yast2-python-bindings < 4.0.1
 Conflicts:      yast2-python3-bindings
+Obsoletes:      yast2-python-bindings < 4.0.1
+%if %{with python2}
+BuildRequires:  python-devel
+%endif
+%if %{with python3}
+BuildRequires:  python3-devel
+%endif
 
 %description -n yast2-python-bindings
 The bindings allow YaST modules to be written using the Python language
 and also Python scripts can use YaST agents, APIs and modules.
 
-%if %{with_python3}
 %package -n yast2-python3-bindings
 Summary:        Python3 bindings for the YaST platform
 Group:          System/YaST
 Requires:       python3
 Requires:       yast2-core
 Requires:       yast2-ycp-ui-bindings
-Obsoletes:      yast2-python-bindings == 4.0.1
 Conflicts:      yast2-python-bindings
+Obsoletes:      yast2-python-bindings = 4.0.1
 
 %description -n yast2-python3-bindings
 The bindings allow YaST modules to be written using the Python language
 and also Python scripts can use YaST agents, APIs and modules.
-%endif
-
-%define builddir %{_builddir}/%{name}-%{version}
 
 %prep
-%setup -n %{name}-%{version}
+%setup -q
 
 %build
-make -f Makefile.cvs all
-%if %{with_python3}
+make %{?_smp_mflags} -f Makefile.cvs all
+%if %{with python3}
 mkdir py3 && pushd py3
 ln -s ../configure configure
-%{configure} --enable-python3
+%configure --enable-python3
 %make_build
 popd
 %endif
+%if %{with python2}
 mkdir py2 && pushd py2
 ln -s ../configure configure
-%{configure}
+%configure
 %make_build
 popd
+%endif
 
 %install
 %if %{with_python3}
 %make_install -C py3
 %endif
+%if %{with python2}
 %make_install -C py2
+%endif
 
-%if %{with_python3}
+%if %{with python3}
 %files -n yast2-python3-bindings
-%defattr (-, root, root)
 %doc %{yast_docdir}
-%{python3_sitelib}/*.py
+%{python3_sitelib}/*
 %{python3_sitearch}/_ycp.so
 %{yast_plugindir}/libpy2lang_python3.so.*
 %{yast_plugindir}/libpy2lang_python3.so
-%exclude %dir %{python3_sitelib}/__pycache__
-%exclude %{python3_sitelib}/__pycache__/*.pyc
-%exclude %{python3_sitelib}/__pycache__/*.pyo
 %exclude %{yast_plugindir}/libpy2lang_python3.la
 %endif
 
+%if %{with python2}
 %files -n yast2-python-bindings
-%defattr (-, root, root)
 %doc %{yast_docdir}
-%{python_sitelib}/*.py
+%{python_sitelib}/*
 %{python_sitearch}/_ycp.so
 %{yast_plugindir}/libpy2lang_python.so.*
 %{yast_plugindir}/libpy2lang_python.so
 %license COPYING
-%exclude %{python_sitelib}/*.pyc
-%exclude %{python_sitelib}/*.pyo
 %exclude %{yast_plugindir}/libpy2lang_python.la
+%endif
 
 %changelog


### PR DESCRIPTION
Package the cache files instead of ignoring them.

Also format the spec a bit to adhere to packaging guidelines.

Waiting for CI to test build it as when I run the docker on local machine with the image it errors out.