### PR TITLE
Don't overwrite CPPFLAGS/LDFLAGS/LIBADD

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 10 23:59:20 UTC 2020 - dmulder@suse.com
+
+- Don't overwrite CPPFLAGS/LDFLAGS/LIBADD during build; (bsc#1163310);
+- 4.1.2
+
+-------------------------------------------------------------------
 Thu Jan  9 09:45:58 UTC 2020 - Tomáš Chvátal <tchvatal@suse.com>
 
 - Switch to python3 on new releases of openSUSE as we no longer

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %bcond_with python2
 %endif
 Name:           yast2-python-bindings
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 BUILT_SOURCES = ycp.py yast.py
 ycp.py yast-core_wrap.cxx: yast-core.i ytypes.i ycp.i $(libpy2UI) YCPMap.h y2log.i
-	$(SWIG) $(AX_SWIG_PYTHON_OPT) -c++ -I/usr/include/YaST2 -o $@ $<
+	$(SWIG) $(AX_SWIG_PYTHON_OPT) -c++ -I/usr/include/YaST2 $(CPPFLAGS) -o $@ $<
 
 yast.py: yast.py.in
 	sed -e 's;[@]DATADIR[@];$(datadir);g' < $(srcdir)/yast.py.in > $(srcdir)/yast.py
@@ -25,22 +25,22 @@ uninstall-hook:
 	(cd $(DESTDIR)/${pyexecdir}; rm -f _ycp.so || echo)
 
 SOURCES = Y2PythonComponent.cc Y2CCPython.cc YPython.cc YPythonNamespace.cc YCPDeclarations.cc yast.cpp yast-core_wrap.cxx Y2PythonClientComponent.cc Y2CCPythonClient.cc YPythonCode.cc PythonLogger.cc
-LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
-LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
-CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
+LIB_LIBADD = -L$(py2langdir) -lpy2UI -lpy2wfm
+LIB_LDFLAGS = -module ${PYTHON_LDFLAGS} -Wl,-rpath=$(pyexecdir)
+LIB_CPPFLAGS = -std=c++11 -I/usr/include/YaST2 ${PYTHON_CPPFLAGS} -Wno-terminate -Wno-format-security -Wno-format-nonliteral
 
 if HAVE_PY3
 py2lang_LTLIBRARIES = libpy2lang_python3.la
 libpy2lang_python3_la_SOURCES = $(SOURCES)
-libpy2lang_python3_la_LIBADD = $(LIBADD)
-libpy2lang_python3_la_LDFLAGS = $(LDFLAGS)
-libpy2lang_python3_la_CPPFLAGS = $(CPPFLAGS)
+libpy2lang_python3_la_LIBADD = $(LIB_LIBADD)
+libpy2lang_python3_la_LDFLAGS = $(LIB_LDFLAGS)
+libpy2lang_python3_la_CPPFLAGS = $(LIB_CPPFLAGS)
 else
 py2lang_LTLIBRARIES = libpy2lang_python.la
 libpy2lang_python_la_SOURCES = $(SOURCES)
-libpy2lang_python_la_LIBADD = $(LIBADD)
-libpy2lang_python_la_LDFLAGS = $(LDFLAGS)
-libpy2lang_python_la_CPPFLAGS = $(CPPFLAGS)
+libpy2lang_python_la_LIBADD = $(LIB_LIBADD)
+libpy2lang_python_la_LDFLAGS = $(LIB_LDFLAGS)
+libpy2lang_python_la_CPPFLAGS = $(LIB_CPPFLAGS)
 endif
 
 AM_CXXFLAGS = -DY2LOG=\"Python\"


### PR DESCRIPTION
Discovered this while build linking against a non-installed yast-core (with custom include/lib dirs).