### PR TITLE
Fix backtrace formatting in YPython::PyErrorHandler() (Merge SLE-15-SP2 into SLE-15-SP3)

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sat Feb 13 18:53:41 UTC 2021 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Fix backtrace formatting for Python exceptions (bsc#1181595).
+- 4.3.0
+
+-------------------------------------------------------------------
 Thu Mar 12 13:30:21 UTC 2020 - Noel Power <nopower@suse.com>
 
 - Fix build for python 3.8; (bsc#1166517)/

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %bcond_with python2
 %endif
 Name:           yast2-python-bindings
-Version:        4.1.3
+Version:        4.3.0
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/src/YPython.cc
+++ b/src/YPython.cc
@@ -488,6 +488,9 @@ string YPython::PyErrorHandler()
     /* get latest python exception info */
     PyErr_Fetch(&errobj, &errdata, &errtraceback);
 
+    /* normalize the value to assure it is be an exception object */
+    PyErr_NormalizeException(&errobj, &errdata, &errtraceback);
+
     pystring = NULL;
     if (errobj != NULL &&
             (pystring = PyObject_Str(errobj)) != NULL &&     /* str(object) */
@@ -541,6 +544,7 @@ string YPython::PyErrorHandler()
         } else {
             result += PyStr_AsString(pystring);
         }
+        Py_XDECREF(mod);
     } else {
         result += "<unknown exception traceback>";
     }


### PR DESCRIPTION
Merge branch SLE-15-SP2 into SLE-15-SP3. This pulls the fixes from #36.