### PR TITLE
Fix backtrace formatting in YPython::PyErrorHandler() [Merge SLE-15-SP3 into master]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 jobs:
   Package:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/sle-15/sp3/containers/yast-cpp:latest
+    container: registry.opensuse.org/yast/head/containers/yast-cpp:latest
 
     steps:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp3
-
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Sat Feb 13 18:53:41 UTC 2021 - Petr Pavlu <petr.pavlu@suse.com>
+Wed Aug 17 18:53:41 UTC 2021 - Petr Pavlu <petr.pavlu@suse.com>
 
 - Fix backtrace formatting for Python exceptions (bsc#1181595).
 - 4.4.1


### PR DESCRIPTION
This PR replaces https://github.com/yast/yast-python-bindings/pull/39 after #38 was merged. It basically

> * Merge branch SLE-15-SP3 into master. This pulls the fixes from #36 and commit b023478808127c5e12a7e3915f3385b03d232bf5.
> * Revert b023478808127c5e12a7e3915f3385b03d232bf5 as it applies only to the SLE-15-SP3 branch (done per https://yastgithubio.readthedocs.io/en/latest/maintenance-branches/#branch-specific-commits).