### PR TITLE
Fix inspect.getargspec() removed from python 3.11

### DIFF
--- a/package/yast2-python-bindings.changes
+++ b/package/yast2-python-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 12 10:10:25 UTC 2023 - Samuel Cabrero <scabrero@suse.de>
+
+- Fix inspect.getargspec() removed in python3.11; (bsc#1215226);
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (#bsc1185510)

--- a/package/yast2-python-bindings.spec
+++ b/package/yast2-python-bindings.spec
@@ -23,7 +23,7 @@
 %bcond_with python2
 %endif
 Name:           yast2-python-bindings
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        Python bindings for the YaST platform
 License:        GPL-2.0-only

--- a/src/YCPDeclarations.py
+++ b/src/YCPDeclarations.py
@@ -98,7 +98,7 @@ class YCPDeclare:
     def _checkNumParams(self, func, numTypes):
         """ Check if number of parameters equals to number of defined types """
 
-        args = len(inspect.getargspec(func)[0])
+        args = len(inspect.getfullargspec(func)[0])
         if args != numTypes:
             raise Exception("Number of declared types does not match number of arguments.")
         


### PR DESCRIPTION
## Problem

inspect.getargspec() removed from python 3.11

https://bugzilla.suse.com/show_bug.cgi?id=1215226

## Solution

Use inspect.getfullargspec()


## Testing

- Tested manually

